### PR TITLE
add `allowScriptTags` option, disabled by default.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ var marky = module.exports = function(markdown, options, callback) {
   options = options || {}
   defaults(options, {
     package: null,
+    allowScriptTags: false,
     highlightSyntax: false,
     serveImagesWithCDN: false,
     debug: false
@@ -51,7 +52,7 @@ var marky = module.exports = function(markdown, options, callback) {
     html = output
 
     log("Sanitize malicious or malformed HTML")
-    html = sanitize(html)
+    html = sanitize(html, options)
 
     log("Turn HTML into DOM object")
     $ = cheerio.load(html)

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -1,15 +1,11 @@
 var sanitizeHtml = require("sanitize-html")
 var url = require("url")
 
-module.exports = function(html) {
-  return sanitizeHtml(html, {
+var sanitizer = module.exports = function(html, options) {
+
+  var config = {
     allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-      "h1",
-      "h2",
-      "img",
-      "meta",
-      "span",
-      "iframe"
+      "h1","h2","img","meta","span","iframe"
     ]),
     allowedClasses: {
       code: [
@@ -50,8 +46,15 @@ module.exports = function(html) {
       iframe: ["src", "frameborder", "allowfullscreen"]
     },
     exclusiveFilter: function(frame) {
+      // Allow YouTube iframes
       if (frame.tag != 'iframe') return false;
       return !String(frame.attribs.src).match(/\/\/(www\.)?youtube\.com/)
     }
-  })
+  }
+
+  if (options.allowScriptTags) {
+    config.allowedTags.push("script")
+  }
+
+  return sanitizeHtml(html, config)
 }

--- a/test/index.js
+++ b/test/index.js
@@ -109,6 +109,14 @@ describe("sanitize", function(){
     assert(!$("script").length)
   })
 
+  it("optionally allows script tags", function(done){
+    assert(~fixtures.dirty.indexOf("<script"))
+    marky(fixtures.dirty, {allowScriptTags: true}, function(err, $){
+      assert.equal($("script").length, 1)
+      done()
+    })
+  })
+
   it("allows img tags", function() {
     assert($("img").length)
   })


### PR DESCRIPTION
Fixes https://github.com/npm/marky-markdown/issues/9