### PR TITLE
[WIP] start using markdown-it and highlights

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,9 +44,6 @@ var marky = module.exports = function(markdown, options, callback) {
   log("Convert HTML frontmatter into meta tags")
   html = frontmatter(markdown)
 
-  log("Remove HTML comments")
-  html = comments(html)
-
   log("Parse markdown into HTML and add syntax highlighting")
   render(html, options, function(err, output) {
     html = output

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,5 +1,8 @@
-var highlighter = new (require("highlights"))()
 var _ = require("lodash")
+var escapeHtml = require('escape-html')
+var highlighter = new (require("highlights"))()
+var MD = require('markdown-it')
+var S = require('string')
 
 module.exports = function(html, options, callback) {
 
@@ -24,7 +27,11 @@ module.exports = function(html, options, callback) {
     }
   }
 
-  html = require('markdown-it')(mdOptions).render(html)
+  // render markdown, we perform automatic
+  // linkifiication of headers.
+  var md = MD(mdOptions)
+  md.renderer.rules.heading_open = headingOpen
+  html = md.render(html)
 
   return callback(null, html)
 }
@@ -37,7 +44,7 @@ function scopeNameFromLang(lang) {
     sh: 'shell'
   }
 
-  lang = mappings[lang] || lang; // mappings for highlights' benefit.
+  lang = mappings[lang] || lang // mappings for highlights' benefit.
 
   var grammar = _.pick(highlighter.registry.grammarsByScopeName, function(val, key) {
     return val.name.toLowerCase() === lang
@@ -45,4 +52,25 @@ function scopeNameFromLang(lang) {
 
   if (Object.keys(grammar).length) return Object.keys(grammar)[0]
   else return 'source.' + lang
+}
+
+// adds anchor ids to headings:
+// original function:
+// https://github.com/markdown-it/markdown-it/blob/master/lib/renderer.js
+function headingOpen(tokens, idx, options, env, self) {
+  return '<h' + tokens[idx].hLevel + generateIdString(tokens[idx + 1]) + '>'
+}
+
+// given the text of an H-tag, generates an id.
+function generateIdString(token) {
+  if (!token || !token.content) return ''
+
+  var id = token.content.toLowerCase()
+  var idPrefix = 'user-content-'
+
+  id = S(id).stripTags().s // remove tags, e.g., <a>
+  id = S(id).stripPunctuation().s // remove punctionation Ben's.
+  id = id.replace(/ /g, '-') // replace remaining spaces with dashes.
+
+  return ' id="' + idPrefix + escapeHtml(id) + '"'
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -4,6 +4,10 @@ var highlighter = new (require("highlights"))()
 var MD = require('markdown-it')
 var S = require('string')
 
+// pre-load grammars, these are used
+// when performing language lookups.
+highlighter.loadGrammarsSync()
+
 module.exports = function(html, options, callback) {
 
   if (!callback) {
@@ -40,8 +44,10 @@ module.exports = function(html, options, callback) {
 // Ruby, JavaScript, fallback to assuming that lang
 // is the extension of the code snippet.
 function scopeNameFromLang(lang) {
+  // alias language names.
   var mappings = {
-    sh: 'shell'
+    sh: 'shell',
+    markdown: 'gfm'
   }
 
   lang = mappings[lang] || lang // mappings for highlights' benefit.

--- a/lib/render.js
+++ b/lib/render.js
@@ -19,7 +19,7 @@ module.exports = function(html, options, callback) {
     mdOptions.highlight = function (code, lang) {
       return highlighter.highlightSync({
         fileContents: code,
-        scopeName: lang
+        scopeName: scopeNameFromLang(lang)
       })
     }
   }
@@ -27,4 +27,22 @@ module.exports = function(html, options, callback) {
   html = require('markdown-it')(mdOptions).render(html)
 
   return callback(null, html)
+}
+
+// attempt to lookup by the long language name, e.g.,
+// Ruby, JavaScript, fallback to assuming that lang
+// is the extension of the code snippet.
+function scopeNameFromLang(lang) {
+  var mappings = {
+    sh: 'shell'
+  }
+
+  lang = mappings[lang] || lang; // mappings for highlights' benefit.
+
+  var grammar = _.pick(highlighter.registry.grammarsByScopeName, function(val, key) {
+    return val.name.toLowerCase() === lang
+  })
+
+  if (Object.keys(grammar).length) return Object.keys(grammar)[0]
+  else return 'source.' + lang
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,5 +1,4 @@
-var pygmentize = require("pygmentize-bundled")
-var marked = require("marked")
+var highlighter = new (require("highlights"))()
 var _ = require("lodash")
 
 module.exports = function(html, options, callback) {
@@ -11,17 +10,21 @@ module.exports = function(html, options, callback) {
 
   options = _.clone(options)
 
-  var markedOptions = {
+  var mdOptions = {
+    html: true,
     langPrefix: "highlight ",
   }
 
   if (options.highlightSyntax) {
-    markedOptions.highlight = function (code, lang, callback) {
-      pygmentize({lang: lang, format: "html"}, code, function (err, result) {
-        return err ? callback(err) : callback(null, result.toString())
+    mdOptions.highlight = function (code, lang) {
+      return highlighter.highlightSync({
+        fileContents: code,
+        scopeName: lang
       })
     }
   }
 
-  return marked(html, markedOptions, callback)
+  html = require('markdown-it')(mdOptions).render(html)
+
+  return callback(null, html)
 }

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -7,7 +7,7 @@ var sanitizer = module.exports = function(html) {
 
 sanitizer.config = {
   allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-    "h1","h2","img","meta","span","iframe"
+    "div","h1","h2","img","meta","pre","span","iframe"
     ]),
     allowedClasses: {
       code: [
@@ -15,6 +15,7 @@ sanitizer.config = {
         "hljs",
         "bash",
         "css",
+        "coffee",
         "coffeescript",
         "glsl",
         "http",
@@ -27,13 +28,15 @@ sanitizer.config = {
         "typescript",
         "xml",
       ],
-      span: Object.keys(require("pygments-tokens")),
+      div: ["line"],
       h1: ['deep-link'],
       h2: ['deep-link'],
       h3: ['deep-link'],
       h4: ['deep-link'],
       h5: ['deep-link'],
       h6: ['deep-link'],
+      pre: ["editor", "editor-colors"],
+      span: require("highlights-tokens"),
     },
     allowedAttributes: {
       h1: ["id"],
@@ -46,7 +49,9 @@ sanitizer.config = {
       img: ["id", "src"],
       meta: ["name", "content"],
       iframe: ["src", "frameborder", "allowfullscreen"],
+      div: [],
       span: [],
+      pre: [],
     },
     exclusiveFilter: function(frame) {
       // Allow YouTube iframes

--- a/package.json
+++ b/package.json
@@ -32,9 +32,12 @@
   "dependencies": {
     "cheerio": "^0.18.0",
     "github-url-to-object": "^1.4.2",
-    "html-frontmatter": "^1.3.1",
+    "highlights": "^0.16.0",
+    "highlights-tokens": "^1.0.1",
+    "html-frontmatter": "^1.3.2",
     "js-beautify": "^1.5.4",
     "lodash": "^2.4.1",
+    "markdown-it": "^3.0.4",
     "marked": "^0.3.2",
     "pretty": "^1.0.0",
     "pygmentize-bundled": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/npm/marky-markdown",
   "dependencies": {
     "cheerio": "^0.18.0",
+    "escape-html": "^1.0.1",
     "github-url-to-object": "^1.4.2",
     "highlights": "^0.16.0",
     "highlights-tokens": "^1.0.1",
@@ -41,7 +42,8 @@
     "marked": "^0.3.2",
     "pretty": "^1.0.0",
     "sanitize-html": "^1.5.1",
-    "similarity": "^1.0.1"
+    "similarity": "^1.0.1",
+    "string": "^3.0.0"
   },
   "devDependencies": {
     "async": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
     "markdown-it": "^3.0.4",
     "marked": "^0.3.2",
     "pretty": "^1.0.0",
-    "pygmentize-bundled": "^2.3.0",
-    "pygments-tokens": "^1.0.1",
     "sanitize-html": "^1.5.1",
     "similarity": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marky-markdown",
-  "version": "2.2.4",
+  "version": "3.0.0",
   "description": "The thing npm uses to clean up READMEs and other markdown files",
   "tagline": "It's like ordinary markdown except it drops its pants for attention.",
   "main": "index.js",

--- a/test/index.js
+++ b/test/index.js
@@ -681,12 +681,6 @@ describe("real readmes in the wild", function() {
       assert($.html().length)
     })
 
-    it("throws out HTML comments", function(){
-      assert(fixtures["johnny-five"].match("<!--"))
-      assert(!$.html().match("<!--"))
-      assert(!$.html().match("&lt;!--"))
-    })
-
   })
 
   describe("wzrd", function() {

--- a/test/index.js
+++ b/test/index.js
@@ -77,11 +77,9 @@ describe("markdown processing and syntax highlighting", function() {
     assert.equal($("code").length, $("code.highlight").length)
   })
 
-  it.only("applies inline syntax highlighting classes to javascript", function(){
-    console.log($("code.js").html())
-    // assert($("code.js pre.editor.editor-colors").length)
-    // assert($("code.js div.line").length)
-    assert($("code.js span.text.plain.null-grammar").length)
+  it("applies inline syntax highlighting classes to javascript", function(){
+    assert($(".js.modifier").length)
+    assert($(".js.function").length)
   })
 
 })

--- a/test/index.js
+++ b/test/index.js
@@ -77,19 +77,11 @@ describe("markdown processing and syntax highlighting", function() {
     assert.equal($("code").length, $("code.highlight").length)
   })
 
-  it("applies inline syntax highlighting classes to javascript", function(){
-    assert($("code.js span.kd").length)
-    assert($("code.js span.nx").length)
-    assert($("code.js span.p").length)
-  })
-
-  it("applies inline syntax highlighting classes to shell", function(){
-    assert($("code.sh span.nb").length)
-  })
-
-  it("applies inline syntax highlighting classes to coffeesript", function(){
-    assert($("code.coffeescript span.nx").length)
-    assert($("code.coffeescript span.s").length)
+  it.only("applies inline syntax highlighting classes to javascript", function(){
+    console.log($("code.js").html())
+    // assert($("code.js pre.editor.editor-colors").length)
+    // assert($("code.js div.line").length)
+    assert($("code.js span.text.plain.null-grammar").length)
   })
 
 })
@@ -112,7 +104,6 @@ describe("sanitize", function(){
   it("can be disabled to allow input from trusted sources", function(done){
     assert(~fixtures.dirty.indexOf("<script"))
     marky(fixtures.dirty, {sanitize: false}, function(err, $){
-      console.log($("script"))
       assert.equal($("script").length, 1)
       assert.equal($("script[src='http://malware.com']").length, 1)
       assert.equal($("script[type='text/javascript']").length, 1)

--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,13 @@ describe("markdown processing and syntax highlighting", function() {
     assert($(".js.function").length)
   })
 
+  it("applies inline syntax highlighting classes to shell", function() {
+    assert($(".shell.builtin").length)
+  })
+
+  it("applies inline syntax highlighting classes to coffeesript", function() {
+    assert($(".coffee.begin").length)
+  })
 })
 
 describe("sanitize", function(){
@@ -485,12 +492,12 @@ describe("headings", function(){
 
   it("injects hashy anchor tags into headings that have DOM ids", function(){
     assert(~fixtures.dirty.indexOf("# h1"))
-    assert($("h1 a[href='#h1']").length)
+    assert($("h1 a[href='#user-content-h1']").length)
   })
 
   it("adds deep-link class to modified headings", function(){
     assert(~fixtures.dirty.indexOf("# h1"))
-    assert($("h1.deep-link a[href='#h1']").length)
+    assert($("h1.deep-link a[href='#user-content-h1']").length)
   })
 
   it("doesn't inject anchor tags into headings that already contain anchors", function(){
@@ -634,8 +641,8 @@ describe("real readmes in the wild", function() {
     })
 
     it("linkifies headings", function(){
-      var link = $("h2#-benchmark-support-.deep-link a")
-      assert.equal(link.attr('href'), "#-benchmark-support-")
+      var link = $("h2#user-content-benchmarksupport.deep-link a")
+      assert.equal(link.attr('href'), "#user-content-benchmarksupport")
       assert.equal(link.text(), "Benchmark.support")
     })
 


### PR DESCRIPTION
This PR is doing two things at once:

- replace marked with markdown-it for better performance and stability
- replace pygments-bundled with highlights for, well, better performance and stability

@bcoe if you end up working on this, notice that I started a span whitelist, but it's still missing some of the tokens: https://github.com/atom/highlights/issues/13

