### PR TITLE
make it synchronous again, now that pygments is out of the mix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ The thing [npmjs.com](https://www.npmjs.com) uses to clean up READMEs and other 
 
 - Parses markdown with [markdown-it](https://github.com/markdown-it/markdown-it), a fast and [commonmark-compliant](http://commonmark.org/) parser.
 - Removes broken and malicious user input with [sanitize-html](https://www.npmjs.com/package/sanitize-html)
-- Highlights code syntax using the [highlights](https://www.npmjs.com/package/highlights) library from [Atom](https://atom.io/).
-- Converts headings (h1, h2, etc) into deep hyperlinks.
+- Applies syntax highlighting to [GitHub-flavored code blocks](https://help.github.com/articles/github-flavored-markdown/#fenced-code-blocks) using the [highlights](https://www.npmjs.com/package/highlights) library from [Atom](https://atom.io/).
+- Converts headings (h1, h2, etc) into anchored hyperlinks.
 - Converts relative GitHub links to their absolute equivalents.
 - Converts relative GitHub images sources to their GitHub raw equivalents.
-- Converts insecure Gravatar URLs to use HTTPS.
+- Converts insecure Gravatar URLs to HTTPS.
 - Wraps embedded YouTube videos so they can be styled.
 - Parses and sanitizes `package.description` as markdown.
 - Applies CSS classes to redundant content that closely matches npm package name and description.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The thing [npmjs.com](https://www.npmjs.com) uses to clean up READMEs and other 
 - Parses markdown with [markdown-it](https://github.com/markdown-it/markdown-it), a fast and [commonmark-compliant](http://commonmark.org/) parser.
 - Removes broken and malicious user input with [sanitize-html](https://www.npmjs.com/package/sanitize-html)
 - Applies syntax highlighting to [GitHub-flavored code blocks](https://help.github.com/articles/github-flavored-markdown/#fenced-code-blocks) using the [highlights](https://www.npmjs.com/package/highlights) library from [Atom](https://atom.io/).
+- Uses [cheerio](https://www.npmjs.com/package/cheerio) to perform various feats of DOM manipulation.
 - Converts headings (h1, h2, etc) into anchored hyperlinks.
 - Converts relative GitHub links to their absolute equivalents.
 - Converts relative GitHub images sources to their GitHub raw equivalents.
@@ -24,20 +25,54 @@ npm install marky-markdown --save
 
 ## Programmatic Usage
 
+marky-markdown exports a single function. For basic use, that function
+takes a single argument: a string to convert.
+
 ```js
 var marky = require("marky-markdown")
-var marky = require("./")
-
-// Here's my basic API
-marky(inputString, [optionsObject])
-
-// Clean up a regular old markdown string
 marky("# hello, I'm markdown").html()
+```
 
-// Pass in an npm `package` object to do stuff like
-// rewriting relative URLs to their absolute equivalent on github,
-// normalizing package metadata with redundant readme content,
-// etcs
+### Options
+
+The exported function takes an optional options object
+as its second argument:
+
+```js
+marky("some trusted string", {sanitize: false}).html()
+```
+
+The default options are as follows:
+
+```js
+{
+  sanitize: true,             // remove script tags and stuff
+  highlightSyntax: true,      // run highlights on fenced code blocks
+  serveImagesWithCDN: false,  // use npm's CDN to proxy images over HTTPS
+  debug: false,               // console.log() all the things
+  package: null,              // npm package metadata
+}
+```
+
+### cheerio "middleware"
+
+marky-markdown always returns the generated HTML document as a [cheerio](https://www.npmjs.com/package/cheerio) DOM object that can be queried using a familiar jQuery syntax:
+
+```js
+var $ = marky("![cat](cat.png)")
+$("img").length
+// => 1
+$("img").attr("src")
+// => "cat.png"
+```
+
+### npm packages
+
+Pass in an npm `package` object to do stuff like rewriting relative URLs
+to their absolute equivalent on GitHub, normalizing package metadata
+with redundant readme content, etc
+
+```js
 var package = {
   name: "foo"
   name: "foo is a thing"
@@ -50,18 +85,6 @@ var package = {
 marky(
   "# hello, I am the foo readme",
   {package: package}
-).html()
-
-// Syntax highlighting is disabled by default.
-marky(
-  "# I'm a file with github flavored markdown",
-  {highlightSyntax: true}
-).html()
-
-// Pass in a `debug` for verbose output
-marky(
-  "# hello, I'm an evil document",
-  {debug: true},
 ).html()
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,22 @@
 # marky-markdown
 
-The thing npm uses to clean up READMEs and other markdown files.
+The thing [npmjs.com](https://www.npmjs.com) uses to clean up READMEs and other markdown files.
 
 ## What it does
 
-- Removes broken and malicious input like script tags and iframes using [sanitize-html](https://www.npmjs.com/package/sanitize-html)
-- Turns headings (h1, h2, etc) into deep links
-- Rewrites relative GitHub links to their absolute equivalents
-- Rewrites relative GitHub images sources to their absolute equivalents
-- Rewrites insecure Gravatar URLs to use HTTPS
-- Highlights code syntax using pygments.
+- Parses markdown with [markdown-it](https://github.com/markdown-it/markdown-it), a fast and [commonmark-compliant](http://commonmark.org/) parser.
+- Removes broken and malicious user input with [sanitize-html](https://www.npmjs.com/package/sanitize-html)
+- Highlights code syntax using the [highlights](https://www.npmjs.com/package/highlights) library from [Atom](https://atom.io/).
+- Converts headings (h1, h2, etc) into deep hyperlinks.
+- Converts relative GitHub links to their absolute equivalents.
+- Converts relative GitHub images sources to their GitHub raw equivalents.
+- Converts insecure Gravatar URLs to use HTTPS.
 - Wraps embedded YouTube videos so they can be styled.
-- Removes redundant content that closely matches npm package name and description
-- Parses `package.description` as markdown
+- Parses and sanitizes `package.description` as markdown.
+- Applies CSS classes to redundant content that closely matches npm package name and description.
 - Applies CSS classes to badge images, so we can do something interesting with them one day.
 
 ## Installation
-
-Download node at [nodejs.org](http://nodejs.org) and install it, if you haven't already.
 
 ```sh
 npm install marky-markdown --save
@@ -27,14 +26,13 @@ npm install marky-markdown --save
 
 ```js
 var marky = require("marky-markdown")
+var marky = require("./")
 
-// Here's the API signature
-marky(inputString, [optionsObject], nodeStyleCallback)
+// Here's my basic API
+marky(inputString, [optionsObject])
 
 // Clean up a regular old markdown string
-marky("# hello, I'm markdown", function(err, $){
-  console.log($.html())
-})
+marky("# hello, I'm markdown").html()
 
 // Pass in an npm `package` object to do stuff like
 // rewriting relative URLs to their absolute equivalent on github,
@@ -51,30 +49,20 @@ var package = {
 
 marky(
   "# hello, I am the foo readme",
-  {package: package},
-  function(err, $) {
-    console.log($.html())
-  }
-)
+  {package: package}
+).html()
 
 // Syntax highlighting is disabled by default.
 marky(
-  "# I'm a string with github flavored markdown",
-  {highlightSyntax: true},
-  function(err, $) {
-    console.log($.html())
-  }
-)
+  "# I'm a file with github flavored markdown",
+  {highlightSyntax: true}
+).html()
 
 // Pass in a `debug` for verbose output
 marky(
   "# hello, I'm an evil document",
   {debug: true},
-  function(err, $) {
-    console.log($.html())
-  }
-)
-
+).html()
 ```
 
 ## Command-line Usage
@@ -93,162 +81,24 @@ marky-markdown some.md > some.html
 npm install
 npm test
 ```
-```
-
-> marky-markdown@1.3.0 test /Users/z/n/marky-markdown
-> mocha
-  before everything
-    ✓ removes the pygments cache directory
-  marky-markdown
-    ✓ is a function
-    ✓ accepts a markdown string and returns a cheerio DOM object
-    ✓ calls back with an error if first argument is not a string
-  markdown processing and syntax highlighting
-    ✓ preserves query parameters in URLs when making them into links
-    ✓ converts github flavored fencing to code blocks
-    ✓ adds js class to javascript blocks
-    ✓ adds sh class to shell blocks
-    ✓ adds sh class to shell blocks
-    ✓ adds hightlight class to all blocks
-    ✓ applies inline syntax highlighting classes to javascript
-    ✓ applies inline syntax highlighting classes to shell
-    ✓ applies inline syntax highlighting classes to coffeesript
-  sanitize
-    ✓ removes script tags
-    ✓ allows img tags
-    ✓ allows h1/h2/h3/h4/h5/h6 tags to preserve their dom id
-    ✓ removes classnames from elements
-    ✓ allows classnames on code tags
-    ✓ disallows iframes from sources other than youtube
-  badges
-    ✓ adds a badge class to img tags containing badge images
-    ✓ adds a badge-only class to p tags containing nothing more than a badge
-  gravatar
-    ✓ replaces insecure gravatar img src URLs with secure HTTPS URLs
-    ✓ leaves secure gravatar URLs untouched
-    ✓ leaves non-gravtar URLs untouched
-  github
-    when package repo is on github
-      ✓ rewrites relative link hrefs to absolute
-      ✓ rewrites slashy relative links hrefs to absolute
-      ✓ leaves protocol-relative URLs alone
-      ✓ leaves hashy URLs alone
-      ✓ replaces relative img URLs with npm CDN URLs
-      ✓ replaces slashy relative img URLs with npm CDN URLs
-      ✓ leaves protocol relative URLs alone
-      ✓ leaves HTTPS URLs alone
-    when package repo is NOT on github
-      ✓ leaves relative URLs alone
-      ✓ leaves slashy relative URLs alone
-      ✓ leaves protocol-relative URLs alone
-      ✓ leaves hashy URLs alone
-      ✓ leaves relative img alone
-      ✓ leaves slashy relative img URLs alone
-      ✓ leaves protocol relative URLs alone
-      ✓ leaves HTTPS URLs alone
-  youtube
-    ✓ wraps iframes in a div for stylability
-    ✓ removes iframe width and height properties
-    ✓ preserves src, frameborder, and allowfullscreen properties
-  packagize
-    name
-      ✓ prepends an h1.package-name element into readme with value of package.name
-      ✓ adds .package-name-redundant class to first h1 if it's similar to package.name
-      ✓ leaves first h1 alone if it differs from package.name
-    description
-      ✓ prepends package.description in a p.package-description element
-      ✓ adds .package-description-redundant class to first h1 if it's similar to package.description
-      ✓ leaves first h1 alone if it differs from package.description
-      ✓ adds .package-description-redundant class to first p if it's similar to package.description
-      ✓ leaves first p alone if it differs from package.description
-  fixtures
-    ✓ is a key-value object
-    ✓ contains stringified markdown files as values
-    ✓ includes some real package readmes right from node_modules
-  headings
-    ✓ injects hashy anchor tags into headings that have DOM ids
-    ✓ adds deep-link class to modified headings
-    ✓ doesn't inject anchor tags into headings that already contain anchors
-  frontmatter
-    ✓ rewrites HTML frontmatter as <meta> tags
-  cdn
-    when serveImagesWithCDN is true
-      ✓ replaces relative img URLs with npm CDN URLs
-      ✓ replaces slashy relative img URLs with npm CDN URLs
-      ✓ leaves protocol relative URLs alone
-      ✓ leaves HTTPS URLs alone
-    when serveImagesWithCDN is false (default)
-      ✓ leaves relative img alone
-      ✓ leaves slashy relative img URLs alone
-      ✓ leaves protocol relative URLs alone
-      ✓ leaves HTTPS URLs alone
-  real readmes in the wild
-    express
-      ✓ successfully parses readme.md
-      ✓ adds package name h1
-      ✓ identifies and marks redundant package description, even when it is not the the first paragraph
-    benchmark
-      ✓ successfully parses
-      ✓ linkifies headings
-    async
-      ✓ successfully parses
-    johnny-five
-      ✓ successfully parses
-      ✓ throws out HTML comments
-    wzrd
-      ✓ successfully parses
-      ✓ processes package description as markdown
-    memoize
-      ✓ successfully parses
-    mkhere
-      ✓ successfully parses
-    cicada
-      ✓ successfully parses
-    flake
-      ✓ successfully parses
-    grunt-angular-templates
-      ✓ successfully parses
-  after everything
-    ✓ removes the pygments cache directory
-  82 passing (840ms)
-
-```
 
 ## Dependencies
 
 - [cheerio](https://github.com/cheeriojs/cheerio): Tiny, fast, and elegant implementation of core jQuery designed specifically for the server
+- [escape-html](https://github.com/component/escape-html): Escape HTML entities
 - [github-url-to-object](https://github.com/zeke/github-url-to-object): Extract user, repo, and other interesting properties from GitHub URLs
+- [highlights](https://github.com/atom/highlights): Syntax highlighter
+- [highlights-tokens](https://github.com/zeke/highlights-tokens): A list of the language tokens used by the Atom.app [highlights](https://www.npmjs.com/package/highlights) syntax highlighter
 - [html-frontmatter](https://github.com/zeke/html-frontmatter): Extract key-value metadata from HTML comments
 - [js-beautify](https://github.com/beautify-web/js-beautify): jsbeautifier.org for node
 - [lodash](https://github.com/lodash/lodash): A utility library delivering consistency, customization, performance, &amp; extras.
+- [markdown-it](https://github.com/markdown-it/markdown-it): Markdown-it - modern pluggable markdown parser.
 - [marked](https://github.com/chjj/marked): A markdown parser built for speed
 - [pretty](https://github.com/jonschlinkert/pretty): Some tweaks for beautifying HTML with js-beautify according to my preferences.
-- [pygmentize-bundled](https://github.com/rvagg/node-pygmentize-bundled): A simple wrapper around Python&#39;s Pygments code formatter, with Pygments bundled
-- [pygmentize-bundled-cached](https://github.com/rvagg/pygmentize-bundled-cached): A caching interface to pygmentize-bundled
-- [pygments-tokens](https://github.com/zeke/pygments-tokens): A map of the tokens used by the pygments syntax highlighter
 - [sanitize-html](https://github.com/punkave/sanitize-html): Clean up user-submitted HTML, preserving whitelisted elements and whitelisted attributes on a per-element basis
 - [similarity](https://github.com/zeke/similarity): How similar are these two strings?
-
-## Dev Dependencies
-
-- [async](https://github.com/caolan/async): Higher-order functions and common patterns for asynchronous code
-- [benchmark](https://github.com/bestiejs/benchmark.js): A benchmarking library that works on nearly all JavaScript platforms, supports high-resolution timers, and returns statistically significant results.
-- [cicada](https://github.com/substack/cicada): a teeny git-based continuous integration server
-- [express](https://github.com/strongloop/express): Fast, unopinionated, minimalist web framework
-- [flake](https://github.com/chilts/flake): Generate practically unique (approximately sortable) IDs in a distributed environment.
-- [grunt-angular-templates](https://github.com/ericclemmons/grunt-angular-templates): Grunt build task to concatenate &amp; register your AngularJS templates in the $templateCache
-- [johnny-five](https://github.com/rwldrn/johnny-five): The JavaScript Hardware Programming Framework. Use with: Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo &amp; Edison, Linino One, Pinoccio, Raspberry Pi, Spark Core, TI Launchpad and more!
-- [memoize](https://github.com/stagas/memoize): memoize caches your callbacks given a set of arguments w/ persistence
-- [mkhere](https://github.com/sanusart/mkhere): Make files based on template
-- [mocha](https://github.com/mochajs/mocha): simple, flexible, fun test framework
-- [package-json-to-readme](https://github.com/zeke/package-json-to-readme): Generate a README.md from package.json contents
-- [rimraf](https://github.com/isaacs/rimraf): A deep deletion module for node (like `rm -rf`)
-- [userhome](https://github.com/shama/userhome): A cross-platform path to the user&#39;s home
-- [wzrd](https://github.com/maxogden/wzrd): Super minimal browserify development server. Inspired by [beefy](http://npmjs.org/beefy) but with less magic
-
+- [string](https://github.com/jprichardson/string.js): string contains methods that aren&#39;t included in the vanilla JavaScript string such as escaping html, decoding html entities, stripping tags, etc.
 
 ## License
 
 ISC
-
-_Generated by [package-json-to-readme](https://github.com/zeke/package-json-to-readme)_

--- a/example.js
+++ b/example.js
@@ -1,12 +1,10 @@
 var marky = require("./")
 
 // Here's my basic API
-marky(inputString, [optionsObject], nodeStyleCallback)
+marky(inputString, [optionsObject])
 
 // Clean up a regular old markdown string
-marky("# hello, I'm markdown", function(err, $){
-  console.log($.html())
-})
+marky("# hello, I'm markdown").html()
 
 // Pass in an npm `package` object to do stuff like
 // rewriting relative URLs to their absolute equivalent on github,
@@ -23,28 +21,19 @@ var package = {
 
 marky(
   "# hello, I am the foo readme",
-  {package: package},
-  function(err, $) {
-    console.log($.html())
-  }
-)
+  {package: package}
+).html()
 
 // Syntax highlighting is disabled by default.
 // To turn it on:
 
 marky(
   "# I'm a file with github flavored markdown",
-  {highlightSyntax: false},
-  function(err, $) {
-    console.log($.html())
-  }
-)
+  {highlightSyntax: false}
+).html()
 
 // Pass in a `debug` for verbose output
 marky(
   "# hello, I'm an evil document",
   {debug: true},
-  function(err, $) {
-    console.log($.html())
-  }
-)
+).html()

--- a/example.js
+++ b/example.js
@@ -24,9 +24,7 @@ marky(
   {package: package}
 ).html()
 
-// Syntax highlighting is disabled by default.
-// To turn it on:
-
+// Disable syntax highlighting
 marky(
   "# I'm a file with github flavored markdown",
   {highlightSyntax: false}

--- a/index.js
+++ b/index.js
@@ -22,10 +22,10 @@ var marky = module.exports = function(markdown, options) {
   options = options || {}
   defaults(options, {
     sanitize: true,
-    package: null,
-    highlightSyntax: false,
+    highlightSyntax: true,
     serveImagesWithCDN: false,
-    debug: false
+    debug: false,
+    package: null,
   })
 
   var log = function(msg) {

--- a/index.js
+++ b/index.js
@@ -12,16 +12,11 @@ var gravatar    = require("./lib/gravatar")
 var headings    = require("./lib/headings")
 var packagize   = require("./lib/packagize")
 
-var marky = module.exports = function(markdown, options, callback) {
+var marky = module.exports = function(markdown, options) {
   var html, $
 
-  if (!callback) {
-    callback = options
-    options = {}
-  }
-
   if (!markdown || typeof markdown !== "string") {
-    return callback(Error("first argument must be a string"))
+    return Error("first argument must be a string")
   }
 
   options = options || {}
@@ -45,41 +40,39 @@ var marky = module.exports = function(markdown, options, callback) {
   html = frontmatter(markdown)
 
   log("Parse markdown into HTML and add syntax highlighting")
-  render(html, options, function(err, output) {
-    html = output
+  html = render(html, options)
 
-    if (options.sanitize) {
-      log("Sanitize malicious or malformed HTML")
-      html = sanitize(html)
-    }
+  if (options.sanitize) {
+    log("Sanitize malicious or malformed HTML")
+    html = sanitize(html)
+  }
 
-    log("Parse HTML into a cheerio DOM object")
-    $ = cheerio.load(html)
+  log("Parse HTML into a cheerio DOM object")
+  $ = cheerio.load(html)
 
-    log("Make gravatar image URLs secure")
-    $ = gravatar($)
+  log("Make gravatar image URLs secure")
+  $ = gravatar($)
 
-    log("Resolve relative GitHub link hrefs")
-    $ = github($, options.package)
+  log("Resolve relative GitHub link hrefs")
+  $ = github($, options.package)
 
-    log("Dress up Youtube iframes")
-    $ = youtube($)
+  log("Dress up Youtube iframes")
+  $ = youtube($)
 
-    log("Add CSS classes to paragraphs containing badges")
-    $ = badges($)
+  log("Add CSS classes to paragraphs containing badges")
+  $ = badges($)
 
-    log("Add fragment hyperlinks links to h1,h2,h3,h4,h5,h6")
-    $ = headings($)
+  log("Add fragment hyperlinks links to h1,h2,h3,h4,h5,h6")
+  $ = headings($)
 
-    log("Inject package name and description into README")
-    $ = packagize($, options.package)
+  log("Inject package name and description into README")
+  $ = packagize($, options.package)
 
-    if (options.serveImagesWithCDN) {
-      log("Rewrite relative image source to use CDN")
-      $ = cdn($, options.package)
-    }
+  if (options.serveImagesWithCDN) {
+    log("Rewrite relative image source to use CDN")
+    $ = cdn($, options.package)
+  }
 
-    return callback(null, $)
-  })
+  return $
 
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -8,12 +8,7 @@ var S = require('string')
 // when performing language lookups.
 highlighter.loadGrammarsSync()
 
-module.exports = function(html, options, callback) {
-
-  if (!callback) {
-    callback = options
-    options = {}
-  }
+module.exports = function(html, options) {
 
   options = _.clone(options)
 
@@ -37,7 +32,7 @@ module.exports = function(html, options, callback) {
   md.renderer.rules.heading_open = headingOpen
   html = md.render(html)
 
-  return callback(null, html)
+  return html
 }
 
 // attempt to lookup by the long language name, e.g.,

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "tagline": "It's like ordinary markdown except it drops its pants for attention.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
-    "doc": "readme package.json --test > README.md"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -53,6 +52,7 @@
     "cordova": "^4.2.0",
     "express": "^4.10.7",
     "flake": "^1.0.0",
+    "glob": "^4.3.5",
     "grunt-angular-templates": "^0.5.7",
     "johnny-five": "^0.8.37",
     "memoize": "~0.1.1",

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,23 +1,30 @@
 var fs = require("fs")
 var path = require("path")
-var fixtures = module.exports = {}
+var glob = require("glob")
+var fixtures = {}
 
+// Read in all the hand-written fixture files
 fs.readdirSync(__dirname + "/fixtures").forEach(function(file) {
   var key = path.basename(file).replace(".md", "")
   fixtures[key] = fs.readFileSync(__dirname + "/fixtures/" + file).toString()
 });
 
-// Packages with a README.md
-"async catjs cordova express grunt-angular-templates johnny-five memoize mkhere".split(" ").forEach(function(pkg) {
-  fixtures[pkg] = fs.readFileSync(__dirname + "/../node_modules/" + pkg + "/README.md", "utf-8")
+// Read in all the devDependencies readmes
+var packages = Object.keys(require("../package.json").devDependencies).concat(
+  Object.keys(require("../package.json").dependencies))
+
+packages.forEach(function(name) {
+  var json = require("../node_modules/" + name + "/package.json")
+  var modulePath = path.resolve("node_modules", name)
+
+  // Find README.md, readme.md, README, readme.markdown, etc
+  var readmeFilename = glob.sync("readme*", {
+    nocase: true,
+    cwd: modulePath
+  })[0]
+
+  var readme = fs.readFileSync(path.resolve(modulePath, readmeFilename), "utf-8")
+  fixtures[name] = readme
 })
 
-// Packages with a readme.md
-"flake wzrd".split(" ").forEach(function(pkg) {
-  fixtures[pkg] = fs.readFileSync(__dirname + "/../node_modules/" + pkg + "/readme.md", "utf-8")
-})
-
-// Packages with a readme.markdown
-"cicada".split(" ").forEach(function(pkg) {
-  fixtures[pkg] = fs.readFileSync(__dirname + "/../node_modules/" + pkg + "/readme.markdown", "utf-8")
-})
+module.exports = fixtures


### PR DESCRIPTION
Per @rockbot's request today, marky-markdown has gone back to its old synchronous API. This is possible because we replaced the async `pygments-bundled` syntax highlighter with `highlights`. This will allow us to keep all of newww's presenters synchronous and consistent across different models like `Package`, `User`, and `Customer`. Plus the sync API is just way simpler.

I also updated the fixtures and "real readmes in the wild" section of the tests to [automatically pull in the READMEs](https://github.com/npm/marky-markdown/blob/c41dbfaa6379add26cf3465aa1d30de7d9d0b6b6/test/fixtures.js#L13-L28) of everything in `dependencies` and `devDependencies`, so testing any wonky package READMEs in the future will be a simple matter of `npm i -D that-wonky-package`.

This is a major change, so we'll wanna bump to 4.0.0 once this is merged. marky-markdown is growing up so fast!