### PR TITLE
linkify fully-qualified URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The default options are as follows:
 ```js
 {
   sanitize: true,             // remove script tags and stuff
+  linkify: true,              // turn orphan URLs into hyperlinks
   highlightSyntax: true,      // run highlights on fenced code blocks
   prefixHeadingIds: true,     // prevent DOM id collisions
   serveImagesWithCDN: false,  // use npm's CDN to proxy images over HTTPS

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var marky = module.exports = function(markdown, options) {
   options = options || {}
   defaults(options, {
     sanitize: true,
+    linkify: true,
     highlightSyntax: true,
     prefixHeadingIds: true,
     serveImagesWithCDN: false,

--- a/lib/render.js
+++ b/lib/render.js
@@ -8,6 +8,7 @@ module.exports = function(html, options) {
 
   var mdOptions = {
     html: true,
+    linkify: options.linkify,
     langPrefix: "highlight ",
   }
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "glob": "^4.3.5",
     "grunt-angular-templates": "^0.5.7",
     "johnny-five": "^0.8.37",
+    "maintenance-modules": "^1.0.2",
     "memoize": "~0.1.1",
     "mkhere": "~1.0.9",
     "mocha": "^2.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -89,10 +89,14 @@ describe("markdown processing and syntax highlighting", function() {
   it("does not encode entities within code blocks", function(){
     assert(~fixtures.enterprise.indexOf("\"name\": \"@myco/anypackage\""))
     var $ = marky(fixtures.enterprise)
-    console.log($("code.js").eq(1).html())
     assert(!~$.html().indexOf("<span>quot</span>"))
     assert(~$.html().indexOf("<span>&quot;</span>"))
-    // assert($("code.js").eq(0).html)
+  })
+
+  it("linkifies fully-qualified URLs", function() {
+    assert(~fixtures['maintenance-modules'].indexOf("- https://github.com/feross/standard"))
+    var $ = marky(fixtures['maintenance-modules'])
+    assert($("a[href='https://github.com/feross/standard']").length)
   })
 })
 


### PR DESCRIPTION
Take a look at [this page](https://www.npmjs.com/package/maintenance-modules):

![screen shot 2015-02-10 at 11 17 17 pm](https://cloud.githubusercontent.com/assets/2289/6143285/0228c49e-b17b-11e4-8f44-729d1f546441.png)

Don't you wish those URLs were links? Well now they can be!

Also, I like how gitx converted `linkify` into `lankily`.