### PR TITLE
Update sanitize-html to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "markdown-it": "^3.0.4",
     "marked": "^0.3.2",
     "pretty": "^1.0.0",
-    "sanitize-html": "^1.5.1",
+    "sanitize-html": "^1.6.1",
     "similarity": "^1.0.1",
     "slug": "^0.8.0"
   },


### PR DESCRIPTION
This fixes a bug evidenced in it's own changelog on npm: https://www.npmjs.com/package/sanitize-html#changelog -- a code block that just contains `undefined` will be squashed to an empty string.