### PR TITLE
stop injecting package metadata into the readme

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var marky = module.exports = function(markdown, options) {
   log("Add fragment hyperlinks links to h1,h2,h3,h4,h5,h6")
   $ = headings($, options)
 
-  log("Inject package name and description into README")
+  log("Apply CSS classes to readme content already expressed by package metadata")
   $ = packagize($, options.package)
 
   if (options.serveImagesWithCDN) {
@@ -76,3 +76,5 @@ var marky = module.exports = function(markdown, options) {
   return $
 
 }
+
+marky.parsePackageDescription = packagize.parsePackageDescription

--- a/lib/packagize.js
+++ b/lib/packagize.js
@@ -4,10 +4,10 @@ var sanitizeHtml = require("sanitize-html")
 var marked = require("marked")
 var cheerio = require("cheerio")
 
-// Inject package.json `name` and `description` into top of file,
-// and add classes to existing elements that look like dupes.
+// Add classes to existing elements that look like dupes
+// of package.name and package.description
 
-module.exports = function($, package) {
+var packagize = module.exports = function($, package) {
 
   if (!package) return $
 
@@ -30,6 +30,7 @@ module.exports = function($, package) {
       h1.addClass("package-description-redundant")
     }
 
+    // Find the first paragraph with text content
     var p = $('p')
       .slice(0,5)
       .filter(function(i, el) {
@@ -40,16 +41,14 @@ module.exports = function($, package) {
     if (similarity(package.description, p.text()) > 0.6) {
       p.addClass("package-description-redundant")
     }
-
-    // Process package.description as a markdown string,
-    // then add it to the top of the readme
-    var $description = cheerio.load(sanitizeHtml(marked(package.description)))
-    $description("p").addClass("package-description")
-    $.root().prepend($description.html())
-
   }
 
-  $.root().prepend(fmt("<h1 class=\"package-name\"><a href=\"#readme\">%s</a></h1>", package.name))
-
   return $
+}
+
+
+packagize.parsePackageDescription = function(description) {
+  var $description = cheerio.load(sanitizeHtml(marked(description)))
+  $description("p").addClass("package-description")
+  return $description
 }

--- a/test/index.js
+++ b/test/index.js
@@ -346,15 +346,6 @@ describe("packagize", function() {
   }
 
   describe("name", function() {
-
-    it("prepends an h1.package-name element into readme with value of package.name", function(){
-      var $ = marky(fixtures.wibble, {package: packages.wibble})
-      assert.equal(
-        $("h1.package-name").text(),
-        packages.wibble.name
-      )
-    })
-
     it("adds .package-name-redundant class to first h1 if it's similar to package.name", function() {
       var $ = marky(fixtures.wibble, {package: packages.wibble})
       assert.equal($("h1.package-name-redundant").length, 1)
@@ -368,14 +359,6 @@ describe("packagize", function() {
   })
 
   describe("description", function() {
-    it("prepends package.description in a p.package-description element", function() {
-      var $ = marky(fixtures.wibble, {package: packages.wibble})
-      assert.equal(
-        $("p.package-description").text(),
-        packages.wibble.description
-      )
-    })
-
     it("adds .package-description-redundant class to first h1 if it's similar to package.description", function() {
       var $ = marky(fixtures.wibble, {package: packages.wobble})
       assert.equal($("h1.package-description-redundant").length, 1)
@@ -396,11 +379,6 @@ describe("packagize", function() {
       var $ = marky(fixtures.wibble, {package: packages.dangledor})
       assert.equal($("p.package-description-redundant").length, 0)
       assert.equal($("p:not(.package-description)").first().text(), "A package called wibble!")
-    })
-
-    it("parses description as markdown and removes script tags", function(){
-      var $ = marky("this is a test", {package: {name: "malice", description: "bad <script>/xss</script> [hax](http://hax.com)"}})
-      assert.equal($("p.package-description").html(), "bad  <a href=\"http://hax.com\">hax</a>")
     })
 
   })
@@ -556,6 +534,19 @@ describe("cdn", function() {
       assert($("img[src='https://secure.com/good.png']").length)
     })
 
+  })
+
+})
+
+describe("package.description parsing", function() {
+
+  it("exposes a description() method for parsing package descriptions", function() {
+    assert.equal(typeof marky.parsePackageDescription, "function")
+  })
+
+  it("parses description as markdown and removes script tags", function(){
+    var $ = marky.parsePackageDescription("bad <script>/xss</script> [hax](http://hax.com)")
+    assert.equal($("p.package-description").html(), "bad  <a href=\"http://hax.com\">hax</a>")
   })
 
 })


### PR DESCRIPTION
npmjs.com package pages will soon have a nav for moving between the package info page and the package access page. This nav will likely sit in the HTML between the package name and the start of the readme itself, so we need more flexibility around how and where package name and description are rendered.

This PR stops injecting package name and description into the readme, leaving it up to www to render the name and description as it sees fit, using the newly exported `marky.parsePackageDescription()` method to continue safely supporting markdowny descriptions.