### PR TITLE
Remove instanceof Error check from CLI

### DIFF
--- a/bin/marky-markdown.js
+++ b/bin/marky-markdown.js
@@ -21,6 +21,5 @@ var filePath = path.resolve(process.cwd(), process.argv[2])
 fs.readFile(filePath, function (err, data) {
   if (err) throw err;
   var $ = marky(data.toString())
-  if ($ instanceof Error) throw $;
   process.stdout.write(pretty($.html()))
 });


### PR DESCRIPTION
Since 40cf5f7 there is no point in this check.