### PR TITLE
Don't assert() outside unit tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var assert      = require("assert")
 var cheerio     = require("cheerio")
 var defaults    = require("lodash").defaults
 var comments    = require("./lib/comments")
@@ -16,7 +15,9 @@ var packagize   = require("./lib/packagize")
 var marky = module.exports = function(markdown, options) {
   var html, $
 
-  assert(typeof markdown === "string", "first argument must be a string")
+  if (typeof markdown !== "string") {
+    throw Error("first argument must be a string")
+  }
 
   options = options || {}
   defaults(options, {


### PR DESCRIPTION
[`assert`](http://nodejs.org/api/assert.html) is not supposed to be used outside unit tests.

> This module is used for writing unit tests for your applications

Using this module in regular code adds an extra dependency that needs to be shimmed in other environments ([browserify shim](https://github.com/defunctzombie/commonjs-assert/blob/master/assert.js) is pretty huge) and most of its methods won't make sense anyway (`throws`, `deepEqual`, `fail`).

Simple `throw` statement here is more than enough.