### PR TITLE
slugg

### DIFF
--- a/lib/headings.js
+++ b/lib/headings.js
@@ -1,5 +1,5 @@
 var fmt = require("util").format
-var slug = require("slug")
+var slug = require("slugg")
 
 var headings = module.exports = function($, options) {
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "markdown-it": "^3.0.4",
     "sanitize-html": "^1.6.1",
     "similarity": "^1.0.1",
-    "slug": "^0.8.0"
+    "slugg": "^0.1.2"
   },
   "devDependencies": {
     "async": "^0.9.0",

--- a/test/index.js
+++ b/test/index.js
@@ -382,7 +382,7 @@ describe("packagize", function() {
     })
   })
 
-  describe.only("parsePackageDescription()", function() {
+  describe("parsePackageDescription()", function() {
     it("is a method for parsing package descriptions", function() {
       assert.equal(typeof marky.parsePackageDescription, "function")
     })


### PR DESCRIPTION
`slug` supports unicode, which is nice, but it also takes a long-ass time to install. It's not worth it. This PR replaces `slug` with `slugg`, which omits unicode but tries to do the right thing: https://www.npmjs.com/package/slugg#usage