### PR TITLE
[WIP] Add support for IDs in headings with links or images

### DIFF
--- a/lib/headings.js
+++ b/lib/headings.js
@@ -10,7 +10,7 @@ var headings = module.exports = function($, options) {
   $("h1,h2,h3,h4,h5,h6").each(function(i, elem) {
 
     // Bail if heading already contains a hyperlink
-    if ($(this).find("a").length) return
+    if ($(this).find("a.deep-anchor").length) return
 
     // Generate an ID based on the heading's innerHTML
     if (!$(this).attr("id")) {
@@ -25,7 +25,7 @@ var headings = module.exports = function($, options) {
     $(this).addClass("deep-link")
 
     $(this).html(fmt(
-      "<a href=\"#%s\">%s</a>",
+      "<a class=\"deep-anchor\" href=\"#%s\"></a>%s",
       $(this).attr("id").replace(headings.prefix, ""),
       $(this).html()
     ))

--- a/test/index.js
+++ b/test/index.js
@@ -114,7 +114,7 @@ describe("sanitize", function(){
   it("allows h1/h2/h3/h4/h5/h6 tags to preserve their dom id", function() {
     assert($("h1").attr("id"))
     assert($("h2").attr("id"))
-    assert(!$("h3").attr("id"))
+    assert($("h3").attr("id"))
     assert($("h4").attr("id"))
     assert($("h5").attr("id"))
     assert($("h6").attr("id"))
@@ -474,7 +474,7 @@ describe("headings", function(){
     assert(~fixtures.payform.indexOf("## Browser `<input>` Helpers"))
     $ = marky(fixtures.payform, {prefixHeadingIds: false})
     assert.equal($("h2#browser-input-helpers a").length, 1)
-    assert.equal($("h2#browser-input-helpers a").html(), "Browser <code>&lt;input&gt;</code> Helpers")
+    assert.equal($("h2#browser-input-helpers").html(), "<a class=\"deep-anchor\" href=\"#browser-input-helpers\"></a>Browser <code>&lt;input&gt;</code> Helpers")
   })
 
 })


### PR DESCRIPTION
The reason for this is that I have lots of docs up on Readme’s, with headings such as `foo.bar(Baz)`, where `foo` links to the docs of the object, and `Baz` links to docs for that class.

It does change some things in the UI of npm though!

*   This adds support for links and images in headings
    by moving the anchor element, which previously wrapped
    the whole heading’s contents, before the contents
    (thus being empty).  In addition, this anchor
    element receives a new class name (`"deep-anchor"`,
    in analogy with `"deep-link"`) to make it stand out
    from other links.

*   The addition does change the UI by no longer making
    headings clickable. Where previously `Foo` was
    completely clickable, now only the `#` preceding the
    heading is clickable (on hover).

*   It does require a change in the styling of npm, e.g.:

    ```css
    .markdown > h2.deep-link a:hover::before {...}
    .markdown > h2.deep-link a::before {...}
    ```

    ...should/might be:

    ```css
    .markdown > h2.deep-link:hover a.deep-anchor::before {...}
    .markdown > h2.deep-link a.deep-anchor::before {...}
    ```

    I tested in out in my web inspecter and things worked
    quite well :)
