### PR TITLE
Standard

### DIFF
--- a/bin/marky-markdown.js
+++ b/bin/marky-markdown.js
@@ -1,18 +1,17 @@
 #!/usr/bin/env node
-
-var fs = require("fs")
-var path = require("path")
-var marky = require("..")
+var fs = require('fs')
+var path = require('path')
+var marky = require('..')
 
 if (process.argv.length < 3) {
-  console.log("Usage:\n\nmarky-markdown some.md > some.html")
-  return
+  console.log('Usage:\n\nmarky-markdown some.md > some.html')
+  process.exit()
 }
 
 var filePath = path.resolve(process.cwd(), process.argv[2])
 
 fs.readFile(filePath, function (err, data) {
-  if (err) throw err;
+  if (err) throw err
   var $ = marky(data.toString())
   process.stdout.write($.html())
-});
+})

--- a/example.js
+++ b/example.js
@@ -1,7 +1,4 @@
-var marky = require("./")
-
-// Here's my basic API
-marky(inputString, [optionsObject])
+var marky = require('./')
 
 // Clean up a regular old markdown string
 marky("# hello, I'm markdown").html()
@@ -10,18 +7,17 @@ marky("# hello, I'm markdown").html()
 // rewriting relative URLs to their absolute equivalent on github,
 // normalizing package metadata with redundant readme content,
 // etcs
-var package = {
-  name: "foo"
-  name: "foo is a thing"
+var pkg = {
+  name: 'foo is a thing',
   repository: {
-    type: "git",
-    url: "https://github.com/kung/foo"
+    type: 'git',
+    url: 'https://github.com/kung/foo'
   }
 }
 
 marky(
-  "# hello, I am the foo readme",
-  {package: package}
+  '# hello, I am the foo readme',
+  {package: pkg}
 ).html()
 
 // Disable syntax highlighting
@@ -33,5 +29,5 @@ marky(
 // Pass in a `debug` for verbose output
 marky(
   "# hello, I'm an evil document",
-  {debug: true},
+  {debug: true}
 ).html()

--- a/index.js
+++ b/index.js
@@ -1,22 +1,22 @@
-var cheerio     = require("cheerio")
-var defaults    = require("lodash").defaults
-var comments    = require("./lib/comments")
-var render      = require("./lib/render")
-var sanitize    = require("./lib/sanitize")
-var badges      = require("./lib/badges")
-var cdn         = require("./lib/cdn")
-var frontmatter = require("./lib/frontmatter")
-var github      = require("./lib/github")
-var youtube     = require("./lib/youtube")
-var gravatar    = require("./lib/gravatar")
-var headings    = require("./lib/headings")
-var packagize   = require("./lib/packagize")
+var cheerio = require('cheerio')
+var defaults = require('lodash').defaults
+// var comments = require('./lib/comments')
+var render = require('./lib/render')
+var sanitize = require('./lib/sanitize')
+var badges = require('./lib/badges')
+var cdn = require('./lib/cdn')
+var frontmatter = require('./lib/frontmatter')
+var github = require('./lib/github')
+var youtube = require('./lib/youtube')
+var gravatar = require('./lib/gravatar')
+var headings = require('./lib/headings')
+var packagize = require('./lib/packagize')
 
-var marky = module.exports = function(markdown, options) {
+var marky = module.exports = function (markdown, options) {
   var html, $
 
-  if (typeof markdown !== "string") {
-    throw Error("first argument must be a string")
+  if (typeof markdown !== 'string') {
+    throw Error('first argument must be a string')
   }
 
   options = options || {}
@@ -26,51 +26,51 @@ var marky = module.exports = function(markdown, options) {
     prefixHeadingIds: true,
     serveImagesWithCDN: false,
     debug: false,
-    package: null,
+    package: null
   })
 
-  var log = function(msg) {
+  var log = function (msg) {
     if (options.debug) {
-      console.log("marky-markdown: " + msg)
+      console.log('marky-markdown: ' + msg)
     }
   }
 
-  log("\n\n" + markdown + "\n\n")
+  log('\n\n' + markdown + '\n\n')
 
-  log("Parse markdown into HTML and add syntax highlighting")
+  log('Parse markdown into HTML and add syntax highlighting')
   html = render(markdown, options)
 
-  log("Convert HTML frontmatter into meta tags")
+  log('Convert HTML frontmatter into meta tags')
   html = frontmatter(html)
 
   if (options.sanitize) {
-    log("Sanitize malicious or malformed HTML")
+    log('Sanitize malicious or malformed HTML')
     html = sanitize(html)
   }
 
-  log("Parse HTML into a cheerio DOM object")
+  log('Parse HTML into a cheerio DOM object')
   $ = cheerio.load(html)
 
-  log("Make gravatar image URLs secure")
+  log('Make gravatar image URLs secure')
   $ = gravatar($)
 
-  log("Resolve relative GitHub link hrefs")
+  log('Resolve relative GitHub link hrefs')
   $ = github($, options.package)
 
-  log("Dress up Youtube iframes")
+  log('Dress up Youtube iframes')
   $ = youtube($)
 
-  log("Add CSS classes to paragraphs containing badges")
+  log('Add CSS classes to paragraphs containing badges')
   $ = badges($)
 
-  log("Add fragment hyperlinks links to h1,h2,h3,h4,h5,h6")
+  log('Add fragment hyperlinks links to h1,h2,h3,h4,h5,h6')
   $ = headings($, options)
 
-  log("Apply CSS classes to readme content already expressed by package metadata")
+  log('Apply CSS classes to readme content already expressed by package metadata')
   $ = packagize($, options.package)
 
   if (options.serveImagesWithCDN) {
-    log("Rewrite relative image source to use CDN")
+    log('Rewrite relative image source to use CDN')
     $ = cdn($, options.package)
   }
 

--- a/lib/badges.js
+++ b/lib/badges.js
@@ -18,39 +18,36 @@ images themselves
 
 */
 
-var URL = require("url")
+var URL = require('url')
 var domains = [
-  "badge.fury.io",
-  "badges.github.io",
-  "badges.gitter.im",
-  "ci.testling.com",
-  "coveralls.io",
-  "david-dm.org",
-  "img.shields.io",
-  "nodei.co",
-  "saucelabs.com",
-  "secure.travis-ci.org",
-  "travis-ci.org",
+  'badge.fury.io',
+  'badges.github.io',
+  'badges.gitter.im',
+  'ci.testling.com',
+  'coveralls.io',
+  'david-dm.org',
+  'img.shields.io',
+  'nodei.co',
+  'saucelabs.com',
+  'secure.travis-ci.org',
+  'travis-ci.org'
 ]
 
-module.exports = function($) {
-
-  domains.forEach(function(domain){
-    $("img[src*='"+domain+"']").each(function(i,el) {
+module.exports = function ($) {
+  domains.forEach(function (domain) {
+    $("img[src*='" + domain + "']").each(function (i, el) {
       var url = URL.parse($(this).attr('src'))
       if (url.host !== domain) return
 
-      $(this).addClass("badge")
+      $(this).addClass('badge')
 
       // If wrapped by a silly p tag that contains no other
       // content, slap a badge-only class on that p tag
-      var wrapper = $(this).closest("p")
-      if ($(wrapper).length && $(wrapper).text() === "") {
-        $(wrapper).addClass("badge-only")
+      var wrapper = $(this).closest('p')
+      if ($(wrapper).length && $(wrapper).text() === '') {
+        $(wrapper).addClass('badge-only')
       }
-
     })
   })
-
   return $
 }

--- a/lib/cdn.js
+++ b/lib/cdn.js
@@ -1,16 +1,14 @@
-var URL = require("url")
-var path = require("path")
-var cdnHost = "https://cdn.npm.im"
+var URL = require('url')
+var path = require('path')
+var cdnHost = 'https://cdn.npm.im'
 
-module.exports = function($, package) {
+module.exports = function ($, pkg) {
+  if (!pkg) return $
+  if (!pkg.name) return $
+  if (!pkg.version) return $
 
-  if (!package) return $
-  if (!package.name) return $
-  if (!package.version) return $
-
-  $("img").each(function(i, el) {
-
-    var url = URL.parse($(this).attr("src"))
+  $('img').each(function (i, el) {
+    var url = URL.parse($(this).attr('src'))
 
     // Skip fully-qualified URLs
     if (url.host) return
@@ -18,7 +16,7 @@ module.exports = function($, package) {
     // Skip protocol-relative URLs
     if (url.path.match(/^\/\//)) return
 
-    $(this).attr("src", cdnHost + "/" + package.name + "@" + package.version + path.join("/", url.href))
+    $(this).attr('src', cdnHost + '/' + pkg.name + '@' + pkg.version + path.join('/', url.href))
 
   })
 

--- a/lib/comments.js
+++ b/lib/comments.js
@@ -1,4 +1,4 @@
 // Remove HTML comments so as not to confuse the markdown parser
-module.exports = function(html) {
-  return html.replace(/<!--[\s\S]*?-->/g, "")
+module.exports = function (html) {
+  return html.replace(/<!--[\s\S]*?-->/g, '')
 }

--- a/lib/frontmatter.js
+++ b/lib/frontmatter.js
@@ -1,14 +1,14 @@
-var cheerio = require("cheerio")
-var fm = require("html-frontmatter")
-var fmt = require("util").format
+var cheerio = require('cheerio')
+var fm = require('html-frontmatter')
+var fmt = require('util').format
 
-module.exports = function(html) {
+module.exports = function (html) {
   var $ = cheerio.load(html)
   var meta = fm(html)
   if (!meta) return html
 
-  Object.keys(meta).reverse().forEach(function(key) {
-    $.root().prepend(fmt("<meta name=\"%s\" content=\"%s\">", key, meta[key]))
+  Object.keys(meta).reverse().forEach(function (key) {
+    $.root().prepend(fmt('<meta name="%s" content="%s">', key, meta[key]))
   })
 
   return $.html()

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,19 +1,17 @@
-var gh = require("github-url-to-object")
-var URL = require("url")
-var path = require("path")
+var gh = require('github-url-to-object')
+var URL = require('url')
+var path = require('path')
 
-module.exports = function($, package) {
+module.exports = function ($, pkg) {
+  if (!pkg) return $
+  if (!pkg.repository) return $
 
-  if (!package) return $
-  if (!package.repository) return $
-
-  var repo = gh(package.repository.url)
+  var repo = gh(pkg.repository.url)
 
   if (!repo) return $
 
-  $("img").each(function(i, el) {
-
-    var src = $(this).attr("src")
+  $('img').each(function (i, el) {
+    var src = $(this).attr('src')
 
     if (!src || !src.length) return
 
@@ -25,18 +23,17 @@ module.exports = function($, package) {
     // Skip protocol-relative URLs
     if (url.path.match(/^\/\//)) return
 
-    $(this).attr("src", "https://raw.githubusercontent.com/" + path.join(
-      repo.user,
-      repo.repo,
-      "master",
-      url.href)
+    $(this).attr('src', 'https://raw.githubusercontent.com/' + path.join(
+        repo.user,
+        repo.repo,
+        'master',
+        url.href)
     )
 
   })
 
-  $("a").each(function(i, el) {
-
-    var href = $(this).attr("href")
+  $('a').each(function (i, el) {
+    var href = $(this).attr('href')
 
     if (!href || !href.length) return
 
@@ -51,7 +48,7 @@ module.exports = function($, package) {
     // Skip protocol-relative URLs
     if (url.path.match(/^\/\//)) return
 
-    $(this).attr("href", repo.https_url + path.join("/blob/master/", url.href))
+    $(this).attr('href', repo.https_url + path.join('/blob/master/', url.href))
 
   })
 

--- a/lib/gravatar.js
+++ b/lib/gravatar.js
@@ -1,15 +1,14 @@
-var URL = require("url")
+var URL = require('url')
 
 // Ensure all gravatar img src URLs are secure
 
-module.exports = function($) {
-
-  $("img[src*='gravatar.com']").each(function(i, el) {
-    var url = URL.parse($(this).attr("src"))
+module.exports = function ($) {
+  $("img[src*='gravatar.com']").each(function (i, el) {
+    var url = URL.parse($(this).attr('src'))
     if (url.host.match(/^(\w+\.)?gravatar\.com$/)) {
-      url.protocol = "https"
-      url.host = "secure.gravatar.com"
-      $(this).attr("src", URL.format(url))
+      url.protocol = 'https'
+      url.host = 'secure.gravatar.com'
+      $(this).attr('src', URL.format(url))
     }
   })
 

--- a/lib/headings.js
+++ b/lib/headings.js
@@ -1,32 +1,30 @@
-var fmt = require("util").format
-var slug = require("slugg")
+var fmt = require('util').format
+var slug = require('slugg')
 
-var headings = module.exports = function($, options) {
-
+var headings = module.exports = function ($, options) {
   if (options && !options.prefixHeadingIds) {
-    headings.prefix = ""
+    headings.prefix = ''
   }
 
-  $("h1,h2,h3,h4,h5,h6").each(function(i, elem) {
-
+  $('h1,h2,h3,h4,h5,h6').each(function (i, elem) {
     // Bail if heading already contains a hyperlink
-    if ($(this).find("a").length) return
+    if ($(this).find('a').length) return
 
     // Generate an ID based on the heading's innerHTML
-    if (!$(this).attr("id")) {
+    if (!$(this).attr('id')) {
       var postfix = slug(
         $(this).text()
-          .replace(/[<>]/g, "") // In case the heading contains `<stuff>`
+          .replace(/[<>]/g, '') // In case the heading contains `<stuff>`
           .toLowerCase()        // because `slug` doesn't lowercase
-        )
-      $(this).attr("id", headings.prefix + postfix)
+      )
+      $(this).attr('id', headings.prefix + postfix)
     }
 
-    $(this).addClass("deep-link")
+    $(this).addClass('deep-link')
 
     $(this).html(fmt(
-      "<a href=\"#%s\">%s</a>",
-      $(this).attr("id").replace(headings.prefix, ""),
+      '<a href="#%s">%s</a>',
+      $(this).attr('id').replace(headings.prefix, ''),
       $(this).html()
     ))
   })

--- a/lib/packagize.js
+++ b/lib/packagize.js
@@ -1,52 +1,46 @@
-var fmt = require("util").format
-var similarity = require("similarity")
-var sanitize = require("./sanitize")
-var markdown = require("markdown-it")({html: true})
-var cheerio = require("cheerio")
+var similarity = require('similarity')
+var sanitize = require('./sanitize')
+var markdown = require('markdown-it')({html: true})
 
 // Add classes to existing elements that look like dupes
-// of package.name and package.description
+// of pkg.name and pkg.description
 
-var packagize = module.exports = function($, package) {
+var packagize = module.exports = function ($, pkg) {
+  if (!pkg) return $
 
-  if (!package) return $
-
-  // mark first h1 if it closely matches package name
+  // mark first h1 if it closely matches pkg name
   var h1 = $('h1').first()
   if (
-    similarity(package.name, h1.text()) > 0.6 ||
-    ~h1.text().toLowerCase().indexOf(package.name.toLowerCase())
+    similarity(pkg.name, h1.text()) > 0.6 ||
+    ~h1.text().toLowerCase().indexOf(pkg.name.toLowerCase())
   ) {
-    h1.addClass("package-name-redundant")
+    h1.addClass('package-name-redundant')
   }
 
-  if (package.description) {
-
-    var h1 = $('h1').first()
+  if (pkg.description) {
     if (
-      similarity(package.description, h1.text()) > 0.6 ||
-      ~h1.text().toLowerCase().indexOf(package.description.toLowerCase())
+      similarity(pkg.description, h1.text()) > 0.6 ||
+      ~h1.text().toLowerCase().indexOf(pkg.description.toLowerCase())
     ) {
-      h1.addClass("package-description-redundant")
+      h1.addClass('package-description-redundant')
     }
 
     // Find the first paragraph with text content
     var p = $('p')
-      .slice(0,5)
-      .filter(function(i, el) {
+      .slice(0, 5)
+      .filter(function (i, el) {
         return $(this).text().length
       })
       .first()
 
-    if (similarity(package.description, p.text()) > 0.6) {
-      p.addClass("package-description-redundant")
+    if (similarity(pkg.description, p.text()) > 0.6) {
+      p.addClass('package-description-redundant')
     }
   }
 
   return $
 }
 
-
-packagize.parsePackageDescription = function(description) {
+packagize.parsePackageDescription = function (description) {
   return sanitize(markdown.renderInline(description))
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,21 +1,26 @@
-var _ = require("lodash")
-var highlighter = new (require("highlights"))()
-var MD = require('markdown-it');
+var _ = require('lodash')
+var highlighter = new (require('highlights'))()
+var MD = require('markdown-it')
+var languages = [
+  'atom-language-nginx',
+  'language-dart',
+  'language-erlang',
+  'language-glsl',
+  'language-haxe',
+  'language-ini',
+  'language-stylus'
+]
 
-// load the additional language packs.
-['language-glsl', 'language-dart', 'language-erlang',
-  'language-stylus', 'language-ini', 'atom-language-nginx',
-  'language-haxe'].forEach(function(language) {
+languages.forEach(function (language) {
   highlighter.requireGrammarsSync({
     modulePath: require.resolve(language + '/package.json')
-  });
-});
+  })
+})
 
-module.exports = function(html, options) {
-
+module.exports = function (html, options) {
   var mdOptions = {
     html: true,
-    langPrefix: "highlight ",
+    langPrefix: 'highlight '
   }
 
   if (options.highlightSyntax) {
@@ -32,7 +37,7 @@ module.exports = function(html, options) {
 
 // attempt to look up by the long language name, e.g. Ruby, JavaScript.
 // fallback to assuming that lang is the extension of the code snippet.
-function scopeNameFromLang(lang) {
+function scopeNameFromLang (lang) {
   // alias language names.
   var mappings = {
     sh: 'source.shell',
@@ -40,9 +45,9 @@ function scopeNameFromLang(lang) {
     erb: 'text.html.erb'
   }
 
-  if (mappings[lang]) return mappings[lang];
+  if (mappings[lang]) return mappings[lang]
 
-  var grammar = _.pick(highlighter.registry.grammarsByScopeName, function(val, key) {
+  var grammar = _.pick(highlighter.registry.grammarsByScopeName, function (val, key) {
     return val.name.toLowerCase() === lang
   })
 

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -1,61 +1,59 @@
-var sanitizeHtml = require("sanitize-html")
-var url = require("url")
-
-var sanitizer = module.exports = function(html) {
+var sanitizeHtml = require('sanitize-html')
+var sanitizer = module.exports = function (html) {
   return sanitizeHtml(html, sanitizer.config)
 }
 
 sanitizer.config = {
   allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-    "div","h1","h2","img","meta","pre","span","iframe"
-    ]),
-    allowedClasses: {
-      code: [
-        "highlight",
-        "hljs",
-        "bash",
-        "css",
-        "coffee",
-        "coffeescript",
-        "glsl",
-        "http",
-        "js",
-        "javascript",
-        "json",
-        "lang-html",
-        "sh",
-        "shell",
-        "typescript",
-        "xml",
-      ],
-      div: ["line"],
-      h1: ['deep-link'],
-      h2: ['deep-link'],
-      h3: ['deep-link'],
-      h4: ['deep-link'],
-      h5: ['deep-link'],
-      h6: ['deep-link'],
-      pre: ["editor", "editor-colors"],
-      span: require("highlights-tokens"),
-    },
-    allowedAttributes: {
-      h1: ["id"],
-      h2: ["id"],
-      h3: ["id"],
-      h4: ["id"],
-      h5: ["id"],
-      h6: ["id"],
-      a: ["href", "id", "name", "target"],
-      img: ["id", "src"],
-      meta: ["name", "content"],
-      iframe: ["src", "frameborder", "allowfullscreen"],
-      div: [],
-      span: [],
-      pre: [],
-    },
-    exclusiveFilter: function(frame) {
-      // Allow YouTube iframes
-      if (frame.tag != 'iframe') return false;
-      return !String(frame.attribs.src).match(/\/\/(www\.)?youtube\.com/)
-    }
+    'div', 'h1', 'h2', 'img', 'meta', 'pre', 'span', 'iframe'
+  ]),
+  allowedClasses: {
+    code: [
+      'highlight',
+      'hljs',
+      'bash',
+      'css',
+      'coffee',
+      'coffeescript',
+      'glsl',
+      'http',
+      'js',
+      'javascript',
+      'json',
+      'lang-html',
+      'sh',
+      'shell',
+      'typescript',
+      'xml'
+    ],
+    div: ['line'],
+    h1: ['deep-link'],
+    h2: ['deep-link'],
+    h3: ['deep-link'],
+    h4: ['deep-link'],
+    h5: ['deep-link'],
+    h6: ['deep-link'],
+    pre: ['editor', 'editor-colors'],
+    span: require('highlights-tokens')
+  },
+  allowedAttributes: {
+    h1: ['id'],
+    h2: ['id'],
+    h3: ['id'],
+    h4: ['id'],
+    h5: ['id'],
+    h6: ['id'],
+    a: ['href', 'id', 'name', 'target'],
+    img: ['id', 'src'],
+    meta: ['name', 'content'],
+    iframe: ['src', 'frameborder', 'allowfullscreen'],
+    div: [],
+    span: [],
+    pre: []
+  },
+  exclusiveFilter: function (frame) {
+    // Allow YouTube iframes
+    if (frame.tag !== 'iframe') return false
+    return !String(frame.attribs.src).match(/\/\/(www\.)?youtube\.com/)
   }
+}

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -1,9 +1,7 @@
-
-module.exports = function($) {
-
+module.exports = function ($) {
   // Wrap YouTube videos in an element so they're easier to style
-  $('iframe[src*="youtube.com"]').each(function(i, elem) {
-    $(this).before("<div class='youtube-video'>" + $(this).toString() + "</div>")
+  $('iframe[src*="youtube.com"]').each(function (i, elem) {
+    $(this).before("<div class='youtube-video'>" + $(this).toString() + '</div>')
     $(this).remove()
   })
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "tagline": "It's like ordinary markdown except it drops its pants for attention.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --timeout 5000"
+    "test": "standard --format && mocha --timeout 5000"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "mkhere": "~1.0.9",
     "mocha": "^2.0.1",
     "payform": "1.0.1",
+    "standard": "^3.7.0",
     "wzrd": "^1.1.1"
   },
   "bin": "./bin/marky-markdown.js",

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,31 +1,29 @@
-var fs = require("fs")
-var path = require("path")
-var glob = require("glob")
+var fs = require('fs')
+var path = require('path')
+var glob = require('glob')
 var fixtures = {}
 
 // Read in all the hand-written fixture files
-fs.readdirSync(__dirname + "/fixtures").forEach(function(file) {
-  var key = path.basename(file).replace(".md", "")
-  fixtures[key] = fs.readFileSync(__dirname + "/fixtures/" + file).toString()
-});
+fs.readdirSync(__dirname + '/fixtures').forEach(function (file) {
+  var key = path.basename(file).replace('.md', '')
+  fixtures[key] = fs.readFileSync(__dirname + '/fixtures/' + file).toString()
+})
 
 // Read in all the devDependencies readmes
-fixtures.packageNames = Object.keys(require("../package.json").devDependencies)
-  .concat(Object.keys(require("../package.json").dependencies))
+fixtures.packageNames = Object.keys(require('../package.json').devDependencies)
+  .concat(Object.keys(require('../package.json').dependencies))
   .sort()
 
-
-fixtures.packageNames.forEach(function(name) {
-  var json = require("../node_modules/" + name + "/package.json")
-  var modulePath = path.resolve("node_modules", name)
+fixtures.packageNames.forEach(function (name) {
+  var modulePath = path.resolve('node_modules', name)
 
   // Find README.md, readme.md, README, readme.markdown, etc
-  var readmeFilename = glob.sync("readme*", {
+  var readmeFilename = glob.sync('readme*', {
     nocase: true,
     cwd: modulePath
   })[0]
 
-  var readme = fs.readFileSync(path.resolve(modulePath, readmeFilename), "utf-8")
+  var readme = fs.readFileSync(path.resolve(modulePath, readmeFilename), 'utf-8')
   fixtures[name] = readme
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,557 +1,550 @@
-var assert = require("assert")
-var fs = require("fs")
-var path = require("path")
-var glob = require("glob")
-var fixtures = require("./fixtures.js")
-var marky = require("..")
+/* globals before, describe, it */
 
-describe("marky-markdown", function() {
+var assert = require('assert')
+var path = require('path')
+var fixtures = require('./fixtures.js')
+var marky = require('..')
 
-  it("is a function", function(){
+describe('marky-markdown', function () {
+  it('is a function', function () {
     assert(marky)
-    assert(typeof marky === "function")
+    assert(typeof marky === 'function')
   })
 
-  it("accepts a markdown string and returns a cheerio DOM object", function(){
-    var $ = marky("hello, world")
+  it('accepts a markdown string and returns a cheerio DOM object', function () {
+    var $ = marky('hello, world')
     assert($.html)
     assert($._root)
     assert($._options)
-    assert(~$.html().indexOf("<p>hello, world</p>\n"))
+    assert(~$.html().indexOf('<p>hello, world</p>\n'))
   })
 
-  it("throws an error if first argument is not a string", function(){
+  it('throws an error if first argument is not a string', function () {
     assert.throws(
-      function() { marky(null) },
+      function () { marky(null) },
       /first argument must be a string/
     )
   })
 
 })
 
-describe("markdown processing and syntax highlighting", function() {
+describe('markdown processing and syntax highlighting', function () {
   var $
-  before(function() {
+  before(function () {
     $ = marky(fixtures.basic, {highlightSyntax: true})
   })
 
   it('preserves query parameters in URLs when making them into links', function () {
-    assert(~fixtures.basic.indexOf("watch?v=dQw4w9WgXcQ"))
+    assert(~fixtures.basic.indexOf('watch?v=dQw4w9WgXcQ'))
     assert.equal($("a[href*='youtube.com']").attr('href'), 'https://www.youtube.com/watch?v=dQw4w9WgXcQ')
-  });
-
-  it("converts github flavored fencing to code blocks", function() {
-    assert(~fixtures.basic.indexOf("```js"))
-    assert($("code").length)
   })
 
-  it("adds js class to javascript blocks", function(){
-    assert(~fixtures.basic.indexOf("```js"))
-    assert($("code.js").length)
+  it('converts github flavored fencing to code blocks', function () {
+    assert(~fixtures.basic.indexOf('```js'))
+    assert($('code').length)
   })
 
-  it("adds sh class to shell blocks", function(){
-    assert(~fixtures.basic.indexOf("```sh"))
-    assert($("code.sh").length)
+  it('adds js class to javascript blocks', function () {
+    assert(~fixtures.basic.indexOf('```js'))
+    assert($('code.js').length)
   })
 
-  it("adds sh class to shell blocks", function(){
-    assert(~fixtures.basic.indexOf("```coffee"))
-    assert($("code.coffeescript").length)
+  it('adds sh class to shell blocks', function () {
+    assert(~fixtures.basic.indexOf('```sh'))
+    assert($('code.sh').length)
   })
 
-  it("adds hightlight class to all blocks", function() {
-    assert.equal($("code").length, $("code.highlight").length)
+  it('adds sh class to shell blocks', function () {
+    assert(~fixtures.basic.indexOf('```coffee'))
+    assert($('code.coffeescript').length)
   })
 
-  it("applies inline syntax highlighting classes to javascript", function(){
-    assert($(".js.modifier").length)
-    assert($(".js.function").length)
+  it('adds hightlight class to all blocks', function () {
+    assert.equal($('code').length, $('code.highlight').length)
   })
 
-  it("applies inline syntax highlighting classes to shell", function() {
-    assert($(".shell.builtin").length)
+  it('applies inline syntax highlighting classes to javascript', function () {
+    assert($('.js.modifier').length)
+    assert($('.js.function').length)
   })
 
-  it("applies inline syntax highlighting classes to coffeesript", function() {
-    assert($(".coffee.begin").length)
+  it('applies inline syntax highlighting classes to shell', function () {
+    assert($('.shell.builtin').length)
   })
 
-  it("does not encode entities within code blocks", function(){
-    assert(~fixtures.enterprise.indexOf("\"name\": \"@myco/anypackage\""))
+  it('applies inline syntax highlighting classes to coffeesript', function () {
+    assert($('.coffee.begin').length)
+  })
+
+  it('does not encode entities within code blocks', function () {
+    assert(~fixtures.enterprise.indexOf('"name": "@myco/anypackage"'))
     var $ = marky(fixtures.enterprise)
-    assert(!~$.html().indexOf("<span>quot</span>"))
-    assert(~$.html().indexOf("<span>&quot;</span>"))
+    assert(!~$.html().indexOf('<span>quot</span>'))
+    assert(~$.html().indexOf('<span>&quot;</span>'))
     // assert($("code.js").eq(0).html)
   })
 })
 
-describe("sanitize", function(){
+describe('sanitize', function () {
   var $
 
-  before(function() {
+  before(function () {
     $ = marky(fixtures.dirty)
   })
 
-  it("removes script tags", function(){
-    assert(~fixtures.dirty.indexOf("<script"))
-    assert(!$("script").length)
+  it('removes script tags', function () {
+    assert(~fixtures.dirty.indexOf('<script'))
+    assert(!$('script').length)
   })
 
-  it("can be disabled to allow input from trusted sources", function(){
-    assert(~fixtures.dirty.indexOf("<script"))
+  it('can be disabled to allow input from trusted sources', function () {
+    assert(~fixtures.dirty.indexOf('<script'))
     var $ = marky(fixtures.dirty, {sanitize: false})
-    assert.equal($("script").length, 1)
+    assert.equal($('script').length, 1)
     assert.equal($("script[src='http://malware.com']").length, 1)
     assert.equal($("script[type='text/javascript']").length, 1)
     assert.equal($("script[charset='utf-8']").length, 1)
   })
 
-  it("allows img tags", function() {
-    assert($("img").length)
+  it('allows img tags', function () {
+    assert($('img').length)
   })
 
-  it("allows h1/h2/h3/h4/h5/h6 tags to preserve their dom id", function() {
-    assert($("h1").attr("id"))
-    assert($("h2").attr("id"))
-    assert(!$("h3").attr("id"))
-    assert($("h4").attr("id"))
-    assert($("h5").attr("id"))
-    assert($("h6").attr("id"))
+  it('allows h1/h2/h3/h4/h5/h6 tags to preserve their dom id', function () {
+    assert($('h1').attr('id'))
+    assert($('h2').attr('id'))
+    assert(!$('h3').attr('id'))
+    assert($('h4').attr('id'))
+    assert($('h5').attr('id'))
+    assert($('h6').attr('id'))
   })
 
-  it("removes classnames from elements", function() {
-    assert(~fixtures.dirty.indexOf("class=\"xxx\""))
-    assert(!$(".xxx").length)
+  it('removes classnames from elements', function () {
+    assert(~fixtures.dirty.indexOf('class="xxx"'))
+    assert(!$('.xxx').length)
   })
 
-  it("allows classnames on code tags", function() {
-    assert($("code.highlight").length)
+  it('allows classnames on code tags', function () {
+    assert($('code.highlight').length)
   })
 
-  it("disallows iframes from sources other than youtube", function() {
+  it('disallows iframes from sources other than youtube', function () {
     var $ = marky(fixtures.basic)
-    assert(~fixtures.basic.indexOf("<iframe src=\"//www.youtube.com/embed/3I78ELjTzlQ"))
-    assert(~fixtures.basic.indexOf("<iframe src=\"//malware.com"))
-    assert.equal($("iframe").length, 1)
-    assert.equal($("iframe").attr("src"), "//www.youtube.com/embed/3I78ELjTzlQ")
+    assert(~fixtures.basic.indexOf('<iframe src="//www.youtube.com/embed/3I78ELjTzlQ'))
+    assert(~fixtures.basic.indexOf('<iframe src="//malware.com'))
+    assert.equal($('iframe').length, 1)
+    assert.equal($('iframe').attr('src'), '//www.youtube.com/embed/3I78ELjTzlQ')
   })
 
 })
 
-describe("badges", function(){
+describe('badges', function () {
   var $
 
-  before(function() {
+  before(function () {
     $ = marky(fixtures.badges)
   })
 
-  it("adds a badge class to img tags containing badge images", function() {
-    assert($("img").length)
-    assert.equal($("img").length, $("img.badge").length)
+  it('adds a badge class to img tags containing badge images', function () {
+    assert($('img').length)
+    assert.equal($('img').length, $('img.badge').length)
   })
 
-  it("adds a badge-only class to p tags containing nothing more than a badge", function() {
-    assert.equal($("p:not(.badge-only)").length, 2)
-    assert.equal($("p.badge-only").length, $("p").length-2)
+  it('adds a badge-only class to p tags containing nothing more than a badge', function () {
+    assert.equal($('p:not(.badge-only)').length, 2)
+    assert.equal($('p.badge-only').length, $('p').length - 2)
   })
 
 })
 
-describe("gravatar", function(){
+describe('gravatar', function () {
   var $
 
-  before(function() {
+  before(function () {
     $ = marky(fixtures.gravatar)
   })
 
-  it("replaces insecure gravatar img src URLs with secure HTTPS URLs", function() {
-    assert(~fixtures.gravatar.indexOf("http://gravatar.com/avatar/123?s=50&d=retro"))
-    assert.equal($("img").length, 3)
-    assert.equal($("img").eq(0).attr('src'), "https://secure.gravatar.com/avatar/123?s=50&d=retro")
+  it('replaces insecure gravatar img src URLs with secure HTTPS URLs', function () {
+    assert(~fixtures.gravatar.indexOf('http://gravatar.com/avatar/123?s=50&d=retro'))
+    assert.equal($('img').length, 3)
+    assert.equal($('img').eq(0).attr('src'), 'https://secure.gravatar.com/avatar/123?s=50&d=retro')
   })
 
-  it("leaves secure gravatar URLs untouched", function() {
-    assert(~fixtures.gravatar.indexOf("https://secure.gravatar.com/avatar/456?s=50&d=retro"))
-    assert.equal($("img").eq(1).attr('src'), "https://secure.gravatar.com/avatar/456?s=50&d=retro")
+  it('leaves secure gravatar URLs untouched', function () {
+    assert(~fixtures.gravatar.indexOf('https://secure.gravatar.com/avatar/456?s=50&d=retro'))
+    assert.equal($('img').eq(1).attr('src'), 'https://secure.gravatar.com/avatar/456?s=50&d=retro')
   })
 
-  it("leaves non-gravtar URLs untouched", function() {
-    assert(~fixtures.gravatar.indexOf("http://not-gravatar.com/foo"))
-    assert.equal($("img").eq(2).attr('src'), "http://not-gravatar.com/foo")
+  it('leaves non-gravtar URLs untouched', function () {
+    assert(~fixtures.gravatar.indexOf('http://not-gravatar.com/foo'))
+    assert.equal($('img').eq(2).attr('src'), 'http://not-gravatar.com/foo')
   })
 
 })
 
-
-describe("github", function(){
-
-  describe("when package repo is on github", function() {
+describe('github', function () {
+  describe('when package repo is on github', function () {
     var $
-    var package = {
-      name: "wahlberg",
+    var pkg = {
+      name: 'wahlberg',
       repository: {
-        type: "git",
-        url: "https://github.com/mark/wahlberg"
+        type: 'git',
+        url: 'https://github.com/mark/wahlberg'
       }
     }
 
-    before(function() {
-      $ = marky(fixtures.github, {package: package})
+    before(function () {
+      $ = marky(fixtures.github, {package: pkg})
     })
 
-    it("rewrites relative link hrefs to absolute", function() {
-      assert(~fixtures.github.indexOf("(relative/file.js)"))
+    it('rewrites relative link hrefs to absolute', function () {
+      assert(~fixtures.github.indexOf('(relative/file.js)'))
       assert($("a[href='https://github.com/mark/wahlberg/blob/master/relative/file.js']").length)
     })
 
-    it("rewrites slashy relative links hrefs to absolute", function() {
-      assert(~fixtures.github.indexOf("(/slashy/poo)"))
+    it('rewrites slashy relative links hrefs to absolute', function () {
+      assert(~fixtures.github.indexOf('(/slashy/poo)'))
       assert($("a[href='https://github.com/mark/wahlberg/blob/master/slashy/poo']").length)
     })
 
-    it("leaves protocol-relative URLs alone", function() {
-      assert(~fixtures.github.indexOf("(//protocollie.com)"))
+    it('leaves protocol-relative URLs alone', function () {
+      assert(~fixtures.github.indexOf('(//protocollie.com)'))
       assert($("a[href='//protocollie.com']").length)
     })
 
-    it("leaves hashy URLs alone", function() {
-      assert(~fixtures.github.indexOf("(#header)"))
+    it('leaves hashy URLs alone', function () {
+      assert(~fixtures.github.indexOf('(#header)'))
       assert($("a[href='#header']").length)
     })
 
-    it("replaces relative img URLs with npm CDN URLs", function() {
-      assert(~fixtures.github.indexOf("![](relative.png)"))
+    it('replaces relative img URLs with npm CDN URLs', function () {
+      assert(~fixtures.github.indexOf('![](relative.png)'))
       assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/master/relative.png']").length)
     })
 
-    it("replaces slashy relative img URLs with npm CDN URLs", function() {
-      assert(~fixtures.github.indexOf("![](/slashy/deep.png)"))
+    it('replaces slashy relative img URLs with npm CDN URLs', function () {
+      assert(~fixtures.github.indexOf('![](/slashy/deep.png)'))
       assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/master/slashy/deep.png']").length)
     })
 
-    it("leaves protocol relative URLs alone", function() {
-      assert(~fixtures.github.indexOf("![](//protocollie.com/woof.png)"))
+    it('leaves protocol relative URLs alone', function () {
+      assert(~fixtures.github.indexOf('![](//protocollie.com/woof.png)'))
       assert($("img[src='//protocollie.com/woof.png']").length)
     })
 
-    it("leaves HTTPS URLs alone", function() {
-      assert(~fixtures.github.indexOf("![](https://secure.com/good.png)"))
+    it('leaves HTTPS URLs alone', function () {
+      assert(~fixtures.github.indexOf('![](https://secure.com/good.png)'))
       assert($("img[src='https://secure.com/good.png']").length)
     })
 
   })
 
-  describe("when package repo is NOT on github", function() {
+  describe('when package repo is NOT on github', function () {
     var $
-    var package = {
-      name: "bitbucketberg",
+    var pkg = {
+      name: 'bitbucketberg',
       repository: {
-        type: "git",
-        url: "https://bitbucket.com/mark/bitbucketberg"
+        type: 'git',
+        url: 'https://bitbucket.com/mark/bitbucketberg'
       }
     }
 
-    before(function() {
-      $ = marky(fixtures.github, {package: package})
+    before(function () {
+      $ = marky(fixtures.github, {package: pkg})
     })
 
-    it("leaves relative URLs alone", function() {
-      assert(~fixtures.github.indexOf("(relative/file.js)"))
+    it('leaves relative URLs alone', function () {
+      assert(~fixtures.github.indexOf('(relative/file.js)'))
       assert($("a[href='relative/file.js']").length)
     })
 
-    it("leaves slashy relative URLs alone", function() {
-      assert(~fixtures.github.indexOf("(/slashy/poo)"))
+    it('leaves slashy relative URLs alone', function () {
+      assert(~fixtures.github.indexOf('(/slashy/poo)'))
       assert($("a[href='/slashy/poo']").length)
     })
 
-    it("leaves protocol-relative URLs alone", function() {
-      assert(~fixtures.github.indexOf("(//protocollie.com)"))
+    it('leaves protocol-relative URLs alone', function () {
+      assert(~fixtures.github.indexOf('(//protocollie.com)'))
       assert($("a[href='//protocollie.com']").length)
     })
 
-    it("leaves hashy URLs alone", function() {
-      assert(~fixtures.github.indexOf("(#header)"))
+    it('leaves hashy URLs alone', function () {
+      assert(~fixtures.github.indexOf('(#header)'))
       assert($("a[href='#header']").length)
     })
 
-    it("leaves relative img alone", function() {
-      assert(~fixtures.github.indexOf("![](relative.png)"))
+    it('leaves relative img alone', function () {
+      assert(~fixtures.github.indexOf('![](relative.png)'))
       assert($("img[src='relative.png']").length)
     })
 
-    it("leaves slashy relative img URLs alone", function() {
-      assert(~fixtures.github.indexOf("![](/slashy/deep.png)"))
+    it('leaves slashy relative img URLs alone', function () {
+      assert(~fixtures.github.indexOf('![](/slashy/deep.png)'))
       assert($("img[src='/slashy/deep.png']").length)
     })
 
-    it("leaves protocol relative URLs alone", function() {
-      assert(~fixtures.github.indexOf("![](//protocollie.com/woof.png)"))
+    it('leaves protocol relative URLs alone', function () {
+      assert(~fixtures.github.indexOf('![](//protocollie.com/woof.png)'))
       assert($("img[src='//protocollie.com/woof.png']").length)
     })
 
-    it("leaves HTTPS URLs alone", function() {
-      assert(~fixtures.github.indexOf("![](https://secure.com/good.png)"))
+    it('leaves HTTPS URLs alone', function () {
+      assert(~fixtures.github.indexOf('![](https://secure.com/good.png)'))
       assert($("img[src='https://secure.com/good.png']").length)
     })
 
-
   })
 
 })
 
-describe("youtube", function() {
+describe('youtube', function () {
   var $
   var iframe
 
-  before(function(){
+  before(function () {
     $ = marky(fixtures.basic)
-    iframe = $(".youtube-video > iframe")
+    iframe = $('.youtube-video > iframe')
   })
 
-  it("wraps iframes in a div for stylability", function() {
-    assert(!~fixtures.basic.indexOf("youtube-video"))
+  it('wraps iframes in a div for stylability', function () {
+    assert(!~fixtures.basic.indexOf('youtube-video'))
     assert.equal(iframe.length, 1)
   })
 
-  it("removes iframe width and height properties", function() {
-    assert.equal(iframe.attr("width"), null)
-    assert.equal(iframe.attr("height"), null)
+  it('removes iframe width and height properties', function () {
+    assert.equal(iframe.attr('width'), null)
+    assert.equal(iframe.attr('height'), null)
   })
 
-  it("preserves src, frameborder, and allowfullscreen properties", function() {
-    assert.equal(iframe.attr("src"), "//www.youtube.com/embed/3I78ELjTzlQ")
-    assert.equal(iframe.attr("frameborder"), "0")
-    assert.equal(iframe.attr("allowfullscreen"), "")
+  it('preserves src, frameborder, and allowfullscreen properties', function () {
+    assert.equal(iframe.attr('src'), '//www.youtube.com/embed/3I78ELjTzlQ')
+    assert.equal(iframe.attr('frameborder'), '0')
+    assert.equal(iframe.attr('allowfullscreen'), '')
   })
 
 })
 
-describe("packagize", function() {
-
+describe('packagize', function () {
   var packages = {
     wibble: {
-      name: "wibble",
-      description: "A package called wibble"
+      name: 'wibble',
+      description: 'A package called wibble'
     },
     wobble: {
-      name: "wobble",
-      description: "wibble"
+      name: 'wobble',
+      description: 'wibble'
     },
     dangledor: {
-      name: "dangledor",
-      description: "dangledor need not roar"
+      name: 'dangledor',
+      description: 'dangledor need not roar'
     }
   }
 
-  describe("name", function() {
-    it("adds .package-name-redundant class to first h1 if it's similar to package.name", function() {
+  describe('name', function () {
+    it("adds .package-name-redundant class to first h1 if it's similar to package.name", function () {
       var $ = marky(fixtures.wibble, {package: packages.wibble})
-      assert.equal($("h1.package-name-redundant").length, 1)
+      assert.equal($('h1.package-name-redundant').length, 1)
     })
 
-    it("leaves first h1 alone if it differs from package.name", function() {
+    it('leaves first h1 alone if it differs from package.name', function () {
       var $ = marky(fixtures.wibble, {package: packages.dangledor})
-      assert.equal($("h1.package-name-redundant").length, 0)
-      assert.equal($("h1:not(.package-name)").text(), "wibble.js")
+      assert.equal($('h1.package-name-redundant').length, 0)
+      assert.equal($('h1:not(.package-name)').text(), 'wibble.js')
     })
   })
 
-  describe("description", function() {
-    it("adds .package-description-redundant class to first h1 if it's similar to package.description", function() {
+  describe('description', function () {
+    it("adds .package-description-redundant class to first h1 if it's similar to package.description", function () {
       var $ = marky(fixtures.wibble, {package: packages.wobble})
-      assert.equal($("h1.package-description-redundant").length, 1)
+      assert.equal($('h1.package-description-redundant').length, 1)
     })
 
-    it("leaves first h1 alone if it differs from package.description", function() {
+    it('leaves first h1 alone if it differs from package.description', function () {
       var $ = marky(fixtures.wibble, {package: packages.dangledor})
-      assert.equal($("h1.package-description-redundant").length, 0)
-      assert.equal($("h1:not(.package-name)").text(), "wibble.js")
+      assert.equal($('h1.package-description-redundant').length, 0)
+      assert.equal($('h1:not(.package-name)').text(), 'wibble.js')
     })
 
-    it("adds .package-description-redundant class to first p if it's similar to package.description", function() {
+    it("adds .package-description-redundant class to first p if it's similar to package.description", function () {
       var $ = marky(fixtures.wibble, {package: packages.wibble})
-      assert.equal($("p.package-description-redundant").length, 1)
+      assert.equal($('p.package-description-redundant').length, 1)
     })
 
-    it("leaves first p alone if it differs from package.description", function() {
+    it('leaves first p alone if it differs from package.description', function () {
       var $ = marky(fixtures.wibble, {package: packages.dangledor})
-      assert.equal($("p.package-description-redundant").length, 0)
-      assert.equal($("p:not(.package-description)").first().text(), "A package called wibble!")
+      assert.equal($('p.package-description-redundant').length, 0)
+      assert.equal($('p:not(.package-description)').first().text(), 'A package called wibble!')
     })
   })
 
-  describe("parsePackageDescription()", function() {
-    it("is a method for parsing package descriptions", function() {
-      assert.equal(typeof marky.parsePackageDescription, "function")
+  describe('parsePackageDescription()', function () {
+    it('is a method for parsing package descriptions', function () {
+      assert.equal(typeof marky.parsePackageDescription, 'function')
     })
 
-    it("parses description as markdown and removes script tags", function(){
-      var description = marky.parsePackageDescription("bad <script>/xss</script> [hax](http://hax.com)")
-      assert.equal(description, "bad  <a href=\"http://hax.com\">hax</a>")
+    it('parses description as markdown and removes script tags', function () {
+      var description = marky.parsePackageDescription('bad <script>/xss</script> [hax](http://hax.com)')
+      assert.equal(description, 'bad  <a href="http://hax.com">hax</a>')
     })
 
-    it("safely handles inline code blocks", function() {
-      var description = marky.parsePackageDescription("Browser `<input type=\"text\">` Helpers")
-      assert.equal(description, "Browser <code>&lt;input type=&quot;text&quot;&gt;</code> Helpers")
+    it('safely handles inline code blocks', function () {
+      var description = marky.parsePackageDescription('Browser `<input type="text">` Helpers')
+      assert.equal(description, 'Browser <code>&lt;input type=&quot;text&quot;&gt;</code> Helpers')
     })
 
-    it("safely handles script tags in inline code blocks", function() {
-      var description = marky.parsePackageDescription("Here comes a `<script>` tag")
-      assert.equal(description, "Here comes a <code>&lt;script&gt;</code> tag")
+    it('safely handles script tags in inline code blocks', function () {
+      var description = marky.parsePackageDescription('Here comes a `<script>` tag')
+      assert.equal(description, 'Here comes a <code>&lt;script&gt;</code> tag')
     })
 
   })
 
 })
 
-describe("fixtures", function() {
-
-  it("is a key-value object", function(){
+describe('fixtures', function () {
+  it('is a key-value object', function () {
     assert(fixtures)
-    assert(typeof fixtures === "object")
+    assert(typeof fixtures === 'object')
     assert(!Array.isArray(fixtures))
   })
 
-  it("contains stringified markdown files as values", function(){
+  it('contains stringified markdown files as values', function () {
     var keys = Object.keys(fixtures)
     assert(keys.length)
-    keys.forEach(function(key) {
+    keys.forEach(function (key) {
       assert(fixtures[key])
-      if (key === "packageNames") return
-      assert(typeof fixtures[key] === "string")
+      if (key === 'packageNames') return
+      assert(typeof fixtures[key] === 'string')
     })
   })
 
-  it("has a property that is an alphabetical list of dependencies", function(){
+  it('has a property that is an alphabetical list of dependencies', function () {
     assert(Array.isArray(fixtures.packageNames))
     assert(fixtures.packageNames.length)
   })
 
-  it("includes some real package readmes right from node_modules", function(){
+  it('includes some real package readmes right from node_modules', function () {
     assert(fixtures.async.length)
     assert(fixtures.express.length)
-    assert(fixtures["johnny-five"].length)
+    assert(fixtures['johnny-five'].length)
   })
 
 })
 
-describe("headings", function(){
+describe('headings', function () {
   var $
 
-  before(function(){
+  before(function () {
     $ = marky(fixtures.dirty)
   })
 
-  it("injects hashy anchor tags into headings that have DOM ids", function(){
-    assert(~fixtures.dirty.indexOf("# h1"))
+  it('injects hashy anchor tags into headings that have DOM ids', function () {
+    assert(~fixtures.dirty.indexOf('# h1'))
     assert($("h1 a[href='#h1']").length)
   })
 
-  it("adds deep-link class to modified headings", function(){
-    assert(~fixtures.dirty.indexOf("# h1"))
+  it('adds deep-link class to modified headings', function () {
+    assert(~fixtures.dirty.indexOf('# h1'))
     assert($("h1.deep-link a[href='#h1']").length)
   })
 
-  it("doesn't inject anchor tags into headings that already contain anchors", function(){
-    assert(~fixtures.dirty.indexOf("### [h3](/already/linky)"))
+  it("doesn't inject anchor tags into headings that already contain anchors", function () {
+    assert(~fixtures.dirty.indexOf('### [h3](/already/linky)'))
     assert($("h3 a[href='/already/linky']").length)
   })
 
-  it("applies a prefix to generated DOM ids by default", function(){
-    assert(~fixtures.dirty.indexOf("## h2"))
-    assert.equal($("h2#user-content-h2").length, 1)
+  it('applies a prefix to generated DOM ids by default', function () {
+    assert(~fixtures.dirty.indexOf('## h2'))
+    assert.equal($('h2#user-content-h2').length, 1)
   })
 
-  it("allows id prefixes to be disabled with prefixHeadingIds", function(){
-    assert(~fixtures.dirty.indexOf("#### This is a TEST"))
+  it('allows id prefixes to be disabled with prefixHeadingIds', function () {
+    assert(~fixtures.dirty.indexOf('#### This is a TEST'))
     $ = marky(fixtures.dirty, {prefixHeadingIds: false})
-    assert.equal($("h4#this-is-a-test").length, 1)
+    assert.equal($('h4#this-is-a-test').length, 1)
   })
 
-  it("encodes innerHTML and removes angle brackets before generating ids", function(){
-    assert(~fixtures.payform.indexOf("## Browser `<input>` Helpers"))
+  it('encodes innerHTML and removes angle brackets before generating ids', function () {
+    assert(~fixtures.payform.indexOf('## Browser `<input>` Helpers'))
     $ = marky(fixtures.payform, {prefixHeadingIds: false})
-    assert.equal($("h2#browser-input-helpers a").length, 1)
-    assert.equal($("h2#browser-input-helpers a").html(), "Browser <code>&lt;input&gt;</code> Helpers")
+    assert.equal($('h2#browser-input-helpers a').length, 1)
+    assert.equal($('h2#browser-input-helpers a').html(), 'Browser <code>&lt;input&gt;</code> Helpers')
   })
 
 })
 
-describe("frontmatter", function() {
-  it("rewrites HTML frontmatter as <meta> tags", function() {
+describe('frontmatter', function () {
+  it('rewrites HTML frontmatter as <meta> tags', function () {
     var $ = marky(fixtures.frontmatter)
     assert($("meta[name='hello']").length)
-    assert.equal($("meta[name='hello']").attr("content"), "world")
+    assert.equal($("meta[name='hello']").attr('content'), 'world')
   })
 })
 
-describe("cdn", function() {
-
-  describe("when serveImagesWithCDN is true", function() {
+describe('cdn', function () {
+  describe('when serveImagesWithCDN is true', function () {
     var $
     var options = {
-      package: {name: "foo", version: "1.0.0"},
+      package: {name: 'foo', version: '1.0.0'},
       serveImagesWithCDN: true
     }
 
-    before(function(){
+    before(function () {
       $ = marky(fixtures.basic, options)
     })
 
-    it("replaces relative img URLs with npm CDN URLs", function() {
-      assert(~fixtures.basic.indexOf("![](relative.png)"))
+    it('replaces relative img URLs with npm CDN URLs', function () {
+      assert(~fixtures.basic.indexOf('![](relative.png)'))
       assert($("img[src='https://cdn.npm.im/foo@1.0.0/relative.png']").length)
     })
 
-    it("replaces slashy relative img URLs with npm CDN URLs", function() {
-      assert(~fixtures.basic.indexOf("![](/slashy/deep.png)"))
+    it('replaces slashy relative img URLs with npm CDN URLs', function () {
+      assert(~fixtures.basic.indexOf('![](/slashy/deep.png)'))
       assert($("img[src='https://cdn.npm.im/foo@1.0.0/slashy/deep.png']").length)
     })
 
-    it("leaves protocol relative URLs alone", function() {
-      assert(~fixtures.basic.indexOf("![](//protocollie.com/woof.png)"))
+    it('leaves protocol relative URLs alone', function () {
+      assert(~fixtures.basic.indexOf('![](//protocollie.com/woof.png)'))
       assert($("img[src='//protocollie.com/woof.png']").length)
     })
 
-    it("leaves HTTPS URLs alone", function() {
-      assert(~fixtures.basic.indexOf("![](https://secure.com/good.png)"))
+    it('leaves HTTPS URLs alone', function () {
+      assert(~fixtures.basic.indexOf('![](https://secure.com/good.png)'))
       assert($("img[src='https://secure.com/good.png']").length)
     })
 
   })
 
-  describe("when serveImagesWithCDN is false (default)", function() {
+  describe('when serveImagesWithCDN is false (default)', function () {
     var $
     var options = {
       package: {
-        name: "foo",
-        version: "1.0.0"
+        name: 'foo',
+        version: '1.0.0'
       }
     }
 
-    before(function(){
+    before(function () {
       $ = marky(fixtures.basic, options)
     })
 
-    it("leaves relative img alone", function() {
-      assert(~fixtures.basic.indexOf("![](relative.png)"))
+    it('leaves relative img alone', function () {
+      assert(~fixtures.basic.indexOf('![](relative.png)'))
       assert($("img[src='relative.png']").length)
     })
 
-    it("leaves slashy relative img URLs alone", function() {
-      assert(~fixtures.basic.indexOf("![](/slashy/deep.png)"))
+    it('leaves slashy relative img URLs alone', function () {
+      assert(~fixtures.basic.indexOf('![](/slashy/deep.png)'))
       assert($("img[src='/slashy/deep.png']").length)
     })
 
-    it("leaves protocol relative URLs alone", function() {
-      assert(~fixtures.basic.indexOf("![](//protocollie.com/woof.png)"))
+    it('leaves protocol relative URLs alone', function () {
+      assert(~fixtures.basic.indexOf('![](//protocollie.com/woof.png)'))
       assert($("img[src='//protocollie.com/woof.png']").length)
     })
 
-    it("leaves HTTPS URLs alone", function() {
-      assert(~fixtures.basic.indexOf("![](https://secure.com/good.png)"))
+    it('leaves HTTPS URLs alone', function () {
+      assert(~fixtures.basic.indexOf('![](https://secure.com/good.png)'))
       assert($("img[src='https://secure.com/good.png']").length)
     })
 
@@ -559,21 +552,20 @@ describe("cdn", function() {
 
 })
 
-describe("real readmes in the wild", function() {
-
-  it("parses readmes of all dependencies and devDependencies", function(done){
+describe('real readmes in the wild', function () {
+  it('parses readmes of all dependencies and devDependencies', function (done) {
     var packages = fixtures.packageNames
 
     assert(Array.isArray(packages))
     assert(packages.length)
-    packages.forEach(function(name) {
-      console.log("\t" + name)
-      assert(typeof fixtures[name] === "string")
-      var json = require(path.resolve("node_modules", name, "package.json"))
+    packages.forEach(function (name) {
+      console.log('\t' + name)
+      assert(typeof fixtures[name] === 'string')
+      var json = require(path.resolve('node_modules', name, 'package.json'))
       var $ = marky(fixtures[name], {package: json})
       assert($.html().length > 100)
 
-      if (name === packages[packages.length-1]) {
+      if (name === packages[packages.length - 1]) {
         return done()
       }
     })


### PR DESCRIPTION
Running `standard --format` on the codebase revealed all sorts of problems:

- lots of declared but unused variables
- leaky globals in tests
- use of reserved keywords
- invalid `example.js` usage script
- improper use of a `return` that should have been a `process.exit()`

This PR fixes all those things, and prepends  `standard --format` to `npm test`