### PR TITLE
Allow `colspan`/`rowspan` on table cells

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -49,7 +49,9 @@ sanitizer.config = {
     iframe: ['src', 'frameborder', 'allowfullscreen'],
     div: [],
     span: [],
-    pre: []
+    pre: [],
+    td: ['colspan', 'rowspan'],
+    th: ['colspan', 'rowspan']
   },
   exclusiveFilter: function (frame) {
     // Allow YouTube iframes


### PR DESCRIPTION
Because I have a module, that has a complex table in it...

By the way, any reason the styling of tables on npm site is the way it is? Github centers (or, rather, does not reset to `left`) the `th`. Also, borders do help... 

Compare:
https://www.npmjs.com/package/gampee#params
vs
https://github.com/insidewarehouse/gampee#params