### PR TITLE
Allow width, height, and valign attributes on img tags

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -44,7 +44,7 @@ sanitizer.config = {
     h5: ['id'],
     h6: ['id'],
     a: ['href', 'id', 'name', 'target'],
-    img: ['id', 'src'],
+    img: ['id', 'src', 'width', 'height', 'valign'],
     meta: ['name', 'content'],
     iframe: ['src', 'frameborder', 'allowfullscreen'],
     div: [],

--- a/test/fixtures/dirty.md
+++ b/test/fixtures/dirty.md
@@ -12,7 +12,7 @@
 
 <script charset="utf-8" src="http://malware.com" type="text/javascript">alert("haxorz")</script>
 
-<img src="local.png"></img>
+<img src="local.png" width="600" height="400" valign="middle" onclick="maliciousClickHandler()"></img>
 
 <a class="xxx" href="http://yyy.com">zzz</a>
 

--- a/test/index.js
+++ b/test/index.js
@@ -107,6 +107,10 @@ describe('sanitize', function () {
 
   it('allows img tags', function () {
     assert($('img').length)
+    assert.equal($('img').attr('width'), "600")
+    assert.equal($('img').attr('height'), "400")
+    assert.equal($('img').attr('valign'), "middle")
+    assert.equal($('img').attr('onclick'), undefined)
   })
 
   it('allows h1/h2/h3/h4/h5/h6 tags to preserve their dom id', function () {


### PR DESCRIPTION
I filed an issue (in hindsight, for the wrong repo) at npm/newww#1107. In short width, height, and valign attributes are allowed on github and disallowed on npmjs.com which makes it rather difficult to achieve visual consistency between the two.

Some examples:

- https://www.npmjs.com/package/gulp-markdown-equations vs. https://github.com/rreusser/gulp-markdown-equations (update: tried SVG on this one, proxying it through rawgit.com to get around strange and seemingly unnecessary github security restrictions)
- https://www.npmjs.com/package/fly vs. https://github.com/flyjs/fly
- https://www.npmjs.com/package/ndarray-blas-level1 vs. https://github.com/scijs/ndarray-blas-level1

Basically any image with a fixed width and height loses it when published to npm (i.e. the only non-css way to use retina images—and I'd use SVG except [SVG has its own issues on github](https://github.com/isaacs/github/issues/316)). I know this will affect the look of quite a few READMEs on npm so I don't take this lightly, but I think there's a pretty good argument to be made that will only fix visual inconsistencies rather than creating them since it's not clear why you'd set these attributes and prefer that they not be obeyed.

Tests are added. I can't think of any other issues like security that this would interfere with.

Thanks for your consideration!