### PR TITLE
make slugs behave more like GitHub

### DIFF
--- a/lib/headings.js
+++ b/lib/headings.js
@@ -1,10 +1,12 @@
 var fmt = require('util').format
-var slug = require('slugg')
+var GithubSlugger = require('github-slugger')
 
 var headings = module.exports = function ($, options) {
   if (options && !options.prefixHeadingIds) {
     headings.prefix = ''
   }
+
+  var slugger = new GithubSlugger()
 
   $('h1,h2,h3,h4,h5,h6').each(function (i, elem) {
     // Bail if heading already contains a hyperlink
@@ -12,7 +14,7 @@ var headings = module.exports = function ($, options) {
 
     // Generate an ID based on the heading's innerHTML
     if (!$(this).attr('id')) {
-      var postfix = slug(
+      var postfix = slugger.slug(
         $(this).text()
           .replace(/[<>]/g, '') // In case the heading contains `<stuff>`
           .toLowerCase() // because `slug` doesn't lowercase

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "atom-language-nginx": "^0.4.0",
     "cheerio": "^0.19.0",
     "github-url-to-object": "^2.1.0",
+    "github-slugger": "^1.0.0",
     "highlights": "^1.3.0",
     "highlights-tokens": "^1.0.1",
     "html-frontmatter": "^1.3.2",
@@ -45,8 +46,7 @@
     "markdown-it": "^5.0.2",
     "property-ttl": "^1.0.0",
     "sanitize-html": "^1.6.1",
-    "similarity": "^1.0.1",
-    "slugg": "^0.1.2"
+    "similarity": "^1.0.1"
   },
   "devDependencies": {
     "async": "^0.9.0",

--- a/test/fixtures/github.md
+++ b/test/fixtures/github.md
@@ -16,3 +16,19 @@
 ![](http://insecure.com/bad.png)
 ![](https://secure.com/good.png)
 ![Methods](#methods)
+
+### heading with a - dash
+
+### heading with a trailing dash -
+
+### heading with an _ underscore
+
+### heading with a period.txt
+
+### duplicate
+
+### duplicate(
+
+### duplicate)
+
+### exchange.bind_headers(exchange, routing [, bindCallback])

--- a/test/index.js
+++ b/test/index.js
@@ -472,6 +472,46 @@ describe('headings', function () {
     assert.equal($('h4#this-is-a-test').length, 1)
   })
 
+  it('allows a dash in generated DOM ids just like GitHub', function () {
+    assert(~fixtures.github.indexOf('### heading with a - dash'))
+    $ = marky(fixtures.github)
+    assert.equal($('h3#heading-with-a---dash a').length, 1)
+  })
+
+  it('allows a trailing dash in generated DOM ids just like GitHub', function () {
+    assert(~fixtures.github.indexOf('### heading with a trailing dash -'))
+    $ = marky(fixtures.github)
+    assert.equal($('h3#heading-with-a-trailing-dash-- a').length, 1)
+  })
+
+  it('allows underscores in generated DOM ids like GitHub', function () {
+    assert(~fixtures.github.indexOf('### heading with an _ underscore'))
+    $ = marky(fixtures.github)
+    assert.equal($('h3#heading-with-an-_-underscore a').length, 1)
+  })
+
+  it('filters periods in generated DOM ids like GitHub', function () {
+    assert(~fixtures.github.indexOf('### heading with a period.txt'))
+    $ = marky(fixtures.github)
+    assert.equal($('h3#heading-with-a-periodtxt').length, 1)
+  })
+
+  it('allows two spaces even after filtering like GitHub', function () {
+    assert(~fixtures.github.indexOf('### exchange.bind_headers(exchange, routing [, bindCallback])'))
+    $ = marky(fixtures.github)
+    assert.equal($('h3#exchangebind_headersexchange-routing--bindcallback').length, 1)
+  })
+
+  it('add suffix to duplicate generated DOM ids like GitHub', function () {
+    assert(~fixtures.github.indexOf('### duplicate'))
+    assert(~fixtures.github.indexOf('### duplicate('))
+    assert(~fixtures.github.indexOf('### duplicate)'))
+    $ = marky(fixtures.github)
+    assert.equal($('h3#duplicate a').length, 1)
+    assert.equal($('h3#duplicate-1 a').length, 1)
+    assert.equal($('h3#duplicate-2 a').length, 1)
+  })
+
   it('encodes innerHTML and removes angle brackets before generating ids', function () {
     assert(~fixtures.payform.indexOf('## Browser `<input>` Helpers'))
     $ = marky(fixtures.payform, {prefixHeadingIds: false})


### PR DESCRIPTION
Thanks for sharing this package, its quite useful! :)

## Problem

I noticed that `marky-markdown` is not consistent with GitHub when generating anchor IDs. Specifically, its filtering out underscores and trailing dashes, which are left alone on GitHub.

Here is what I saw coming out of `marky-markdown`:
```
> var md = require('marky-markdown')
> md('## test(\n## test)\n## test_\n## test-\n## test=\n').html()
```
```html
<h2 id="user-content-test" class="deep-link"><a href="#test">test(</a></h2>
<h2 id="user-content-test" class="deep-link"><a href="#test">test)</a></h2>
<h2 id="user-content-test" class="deep-link"><a href="#test">test_</a></h2>
<h2 id="user-content-test" class="deep-link"><a href="#test">test-</a></h2>
<h2 id="user-content-test" class="deep-link"><a href="#test">test=</a></h2>
```

...and here is an example of what GitHub does (pulling from this this [gist](https://gist.github.com/Flet/1f46a2af2f6b3bf378cf)):
```html
<h2><a id="user-content-test-14" class="anchor" href="#test-14" aria-hidden="true"><span class="octicon octicon-link"></span></a>test(</h2>
<h2><a id="user-content-test-15" class="anchor" href="#test-15" aria-hidden="true"><span class="octicon octicon-link"></span></a>test)</h2>
<h2><a id="user-content-test_" class="anchor" href="#test_" aria-hidden="true"><span class="octicon octicon-link"></span></a>test_</h2>
<h2><a id="user-content-test-" class="anchor" href="#test-" aria-hidden="true"><span class="octicon octicon-link"></span></a>test-</h2>
<h2><a id="user-content-test-16" class="anchor" href="#test-16" aria-hidden="true"><span class="octicon octicon-link"></span></a>test=</h2>
```

`marky-markdown` relies on `slugg` for which deviates from [GitHub's punctuation filtering behavior](https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb#L35).

The other problem is that some IDs become duplicates after being filtered. `marky-markdown` made all the IDs `test`, but GitHub will add a suffix to ensure they are unique ('test', 'test-2', 'test-3').

## Solution
This PR switches from `slugg` to [`slugger-unique`](https://github.com/flet/slugger-unique), which uses [`slugger`](https://github.com/HenrikJoreteg/slugger) to generate unique IDs. `slugger-unique` takes it further by adding a suffix for duplicate IDs, mimicking GitHub's behavior.

Tests have also been added to cover the cases mentioned.

