### PR TITLE
add support for ~~strikethrough~~

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -5,7 +5,7 @@ var sanitizer = module.exports = function (html) {
 
 sanitizer.config = {
   allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-    'div', 'h1', 'h2', 'img', 'meta', 'pre', 'span', 'iframe'
+    'div', 'h1', 'h2', 'img', 'meta', 'pre', 'span', 'iframe', 's'
   ]),
   allowedClasses: {
     code: [

--- a/test/fixtures/dirty.md
+++ b/test/fixtures/dirty.md
@@ -16,6 +16,8 @@
 
 <a class="xxx" href="http://yyy.com">zzz</a>
 
+My favorite color is ~~orange~~ red.
+
 ```js
 console.log("hello world")
 ```

--- a/test/index.js
+++ b/test/index.js
@@ -131,6 +131,11 @@ describe('sanitize', function () {
     assert($('code.highlight').length)
   })
 
+  it('allows the <s> strikethrough element', function () {
+    assert(~fixtures.dirty.indexOf('~~orange~~'))
+    assert.equal($('s').text(), 'orange')
+  })
+
   it('disallows iframes from sources other than youtube', function () {
     var $ = marky(fixtures.basic)
     assert(~fixtures.basic.indexOf('<iframe src="//www.youtube.com/embed/3I78ELjTzlQ'))


### PR DESCRIPTION
The markdown-it parser supports [GFM-style strikethrough](https://github.com/markdown-it/markdown-it#syntax-extensions), but the `<s>` element was not allowed by marky-markdown's sanitizer. This PR adds it to the whitelist.

> The HTML Strikethrough Element (`<s>`) renders text with a strikethrough, or a line through it. Use the `<s>` element to represent things that are no longer relevant or no longer accurate.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element

Fixes https://github.com/npm/newww/issues/1065; cc @jamestalmage