### PR TITLE
linkify fully-qualified URLs (redo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The default options are as follows:
 ```js
 {
   sanitize: true,             // remove script tags and stuff
+  linkify: true,              // turn orphan URLs into hyperlinks
   highlightSyntax: true,      // run highlights on fenced code blocks
   prefixHeadingIds: true,     // prevent DOM id collisions
   serveImagesWithCDN: false,  // use npm's CDN to proxy images over HTTPS

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var marky = module.exports = function (markdown, options) {
   options = options || {}
   defaults(options, {
     sanitize: true,
+    linkify: true,
     highlightSyntax: true,
     prefixHeadingIds: true,
     serveImagesWithCDN: false,

--- a/lib/render.js
+++ b/lib/render.js
@@ -29,7 +29,8 @@ cleanup(highlighter.registry.grammars)
 module.exports = function (html, options) {
   var mdOptions = {
     html: true,
-    langPrefix: 'highlight '
+    langPrefix: 'highlight ',
+    linkify: options.linkify
   }
 
   if (options.highlightSyntax) {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "glob": "^4.3.5",
     "grunt-angular-templates": "^0.5.7",
     "johnny-five": "^0.8.37",
+    "maintenance-modules": "1.0.2",
     "memoize": "~0.1.1",
     "mkhere": "~1.0.9",
     "mocha": "^2.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,12 @@ describe('markdown processing and syntax highlighting', function () {
     assert(!~$.html().indexOf('<span>quot</span>'))
     assert(~$.html().indexOf('<span>&quot;</span>'))
   })
+
+  it('linkifies fully-qualified URLs', function () {
+    assert(~fixtures['maintenance-modules'].indexOf('- https://gist.github.com/sindresorhus/8435329'))
+    var $ = marky(fixtures['maintenance-modules'])
+    assert($("a[href='https://gist.github.com/sindresorhus/8435329']").length)
+  })
 })
 
 describe('sanitize', function () {


### PR DESCRIPTION
This is a followup to #19, opened from my fork because I no longer have commit access to the canonical repo. When enabled, the linkify feature automatically converts fully-qualified URLs (in inline text) into links:

Markdown before:

```md
My favorite website is http://zombo.com
```

HTML after:

```html
<p>My favorite website is <a href="http://zombo.com">http://zombo.com</a><p>
```

The linkify feature is enabled by default. To disable it, set an option:

```js
marky(myText, {linkify: false})
```

This update exposes the [`linkify` option from markdown-it](https://github.com/markdown-it/markdown-it#linkify), which is powered by the standalone [linkify-it](https://github.com/markdown-it/linkify-it) module. The `maintenance-modules` devDependency is added because it happens to be a package with fully-qualified URLs in its readme.