### PR TITLE
Add support for markdown headings lacking spaces between the #(s) and heading text

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1,6 +1,7 @@
 var _ = require('lodash')
 var Highlights = require('highlights')
 var MD = require('markdown-it')
+var lazyHeaders = require('markdown-it-lazy-headers')
 var cleanup = require('./cleanup')
 
 var highlighter = new Highlights()
@@ -41,7 +42,8 @@ module.exports = function (html, options) {
     }
   }
 
-  return MD(mdOptions).render(html)
+  var parser = MD(mdOptions).use(lazyHeaders)
+  return parser.render(html)
 }
 
 var mappings = {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "language-stylus": "^0.5.2",
     "lodash": "^3.10.1",
     "markdown-it": "^5.0.2",
+    "markdown-it-lazy-headers": "^0.1.3",
     "property-ttl": "^1.0.0",
     "sanitize-html": "^1.6.1",
     "similarity": "^1.0.1",

--- a/test/fixtures/lazyheading.md
+++ b/test/fixtures/lazyheading.md
@@ -1,0 +1,12 @@
+
+#lazy heading 1
+
+##lazy heading 2
+
+###lazy heading 3
+
+####lazy heading 4
+
+#####lazy heading 5
+
+######lazy heading 6

--- a/test/index.js
+++ b/test/index.js
@@ -479,6 +479,17 @@ describe('headings', function () {
     assert.equal($('h2#browser-input-helpers a').html(), 'Browser <code>&lt;input&gt;</code> Helpers')
   })
 
+  it('properly handles headings lacking a space between the leading #(s) and heading text', function () {
+    assert(~fixtures.lazyheading.indexOf('#lazy heading'))
+    $ = marky(fixtures.lazyheading, {prefixHeadingIds: false})
+    assert.equal($('h1#lazy-heading-1').length, 1)
+    assert.equal($('h2#lazy-heading-2').length, 1)
+    assert.equal($('h3#lazy-heading-3').length, 1)
+    assert.equal($('h4#lazy-heading-4').length, 1)
+    assert.equal($('h5#lazy-heading-5').length, 1)
+    assert.equal($('h6#lazy-heading-6').length, 1)
+  })
+
 })
 
 describe('frontmatter', function () {


### PR DESCRIPTION
This little update handles issue #39 by using the [markdown-it-lazy-headers](https://www.npmjs.com/package/markdown-it-lazy-headers) module to allow authors to omit the (technically required, per the [CommonMark Spec](http://spec.commonmark.org/0.17/#atx-headers)) space(s) between the leading `#` character(s) and the heading text. It includes a short test fixture as well.

Prior to this update, `#hello` gets rendered as `<p>#hello</p>`, but now it becomes a proper `<h1>hello</h1>`. Likewise for `h2`–`h6`.