### PR TITLE
Whitelist the ins, del, sub, and sup HTML elements

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -5,7 +5,7 @@ var sanitizer = module.exports = function (html) {
 
 sanitizer.config = {
   allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-    'div', 'h1', 'h2', 'img', 'meta', 'pre', 'span', 'iframe', 's'
+    'del', 'div', 'h1', 'h2', 'iframe', 'img', 'ins', 'meta', 'pre', 's', 'span', 'sub', 'sup'
   ]),
   allowedClasses: {
     code: [
@@ -51,7 +51,9 @@ sanitizer.config = {
     span: [],
     pre: [],
     td: ['colspan', 'rowspan'],
-    th: ['colspan', 'rowspan']
+    th: ['colspan', 'rowspan'],
+    del: ['cite', 'datetime'],
+    ins: ['cite', 'datetime']
   },
   exclusiveFilter: function (frame) {
     // Allow YouTube iframes

--- a/test/fixtures/dirty.md
+++ b/test/fixtures/dirty.md
@@ -21,3 +21,11 @@ My favorite color is ~~orange~~ red.
 ```js
 console.log("hello world")
 ```
+
+some<sub>subscript</sub>
+
+some<sup>superscript</sup>
+
+<del>deleted</del>
+
+<ins>inserted</ins>

--- a/test/index.js
+++ b/test/index.js
@@ -144,6 +144,26 @@ describe('sanitize', function () {
     assert.equal($('iframe').attr('src'), '//www.youtube.com/embed/3I78ELjTzlQ')
   })
 
+  it('allows the <ins> element', function () {
+    assert(~fixtures.dirty.indexOf('<ins>'))
+    assert.equal($('ins').text(), 'inserted')
+  })
+
+  it('allows the <del> element', function () {
+    assert(~fixtures.dirty.indexOf('<del>'))
+    assert.equal($('del').text(), 'deleted')
+  })
+
+  it('allows the <sub> element', function () {
+    assert(~fixtures.dirty.indexOf('<sub>'))
+    assert.equal($('sub').text(), 'subscript')
+  })
+
+  it('allows the <sup> element', function () {
+    assert(~fixtures.dirty.indexOf('<sup>'))
+    assert.equal($('sup').text(), 'superscript')
+  })
+
 })
 
 describe('badges', function () {


### PR DESCRIPTION
Per issue #55, this update white lists a few HTML elements from [GitHub's whitelist](https://github.com/jch/html-pipeline/blob/2a55955b5da482624df95ff5cf88ba7ff522e97a/lib/html/pipeline/sanitization_filter.rb#L112). Most of the elements in that list are already allowed, so this just adds `del`, `ins`, `sub`, and `sup` (and it alphabetizes the array for `allowedTags`). There's also a simple test fixture for each.