### PR TITLE
Support diff syntax highlighting

### DIFF
--- a/lib/highlights-tokens.js
+++ b/lib/highlights-tokens.js
@@ -1,0 +1,8 @@
+var stockHighlightsTokens = require('highlights-tokens')
+var diffTokens = require('atom-language-diff')
+
+
+// combine stock highlights tokens list with any additional ones we've included
+
+module.exports = [].concat(stockHighlightsTokens, diffTokens)
+

--- a/lib/highlights-tokens.js
+++ b/lib/highlights-tokens.js
@@ -1,8 +1,6 @@
 var stockHighlightsTokens = require('highlights-tokens')
 var diffTokens = require('atom-language-diff')
 
-
 // combine stock highlights tokens list with any additional ones we've included
 
 module.exports = [].concat(stockHighlightsTokens, diffTokens)
-

--- a/lib/render.js
+++ b/lib/render.js
@@ -8,6 +8,7 @@ var highlighter = new Highlights()
 
 var languages = [
   'atom-language-nginx',
+  'atom-language-diff',
   'language-dart',
   'language-rust',
   'language-erlang',

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -15,6 +15,7 @@ sanitizer.config = {
       'css',
       'coffee',
       'coffeescript',
+      'diff',
       'glsl',
       'http',
       'js',
@@ -34,7 +35,7 @@ sanitizer.config = {
     h5: ['deep-link'],
     h6: ['deep-link'],
     pre: ['editor', 'editor-colors'],
-    span: require('highlights-tokens')
+    span: require('./highlights-tokens')
   },
   allowedAttributes: {
     h1: ['id'],

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/npm/marky-markdown",
   "dependencies": {
+    "atom-language-diff": "^1.0.0",
     "atom-language-nginx": "^0.4.0",
     "cheerio": "^0.19.0",
     "github-url-to-object": "^2.1.0",

--- a/test/fixtures/basic.md
+++ b/test/fixtures/basic.md
@@ -23,6 +23,11 @@ echo hi
 alert "hi"
 ```
 
+```diff
+-removed
++added
+```
+
 ### images
 
 ![](relative.png)

--- a/test/index.js
+++ b/test/index.js
@@ -54,7 +54,7 @@ describe('markdown processing and syntax highlighting', function () {
     assert($('code.sh').length)
   })
 
-  it('adds sh class to shell blocks', function () {
+  it('adds coffeescript class to coffee blocks', function () {
     assert(~fixtures.basic.indexOf('```coffee'))
     assert($('code.coffeescript').length)
   })
@@ -72,7 +72,7 @@ describe('markdown processing and syntax highlighting', function () {
     assert($('.shell.builtin').length)
   })
 
-  it('applies inline syntax highlighting classes to coffeesript', function () {
+  it('applies inline syntax highlighting classes to coffeescript', function () {
     assert($('.coffee.begin').length)
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -59,6 +59,11 @@ describe('markdown processing and syntax highlighting', function () {
     assert($('code.coffeescript').length)
   })
 
+  it('adds diff class to diff blocks', function () {
+    assert(~fixtures.basic.indexOf('```diff'))
+    assert($('code.diff').length)
+  })
+
   it('adds hightlight class to all blocks', function () {
     assert.equal($('code').length, $('code.highlight').length)
   })
@@ -74,6 +79,11 @@ describe('markdown processing and syntax highlighting', function () {
 
   it('applies inline syntax highlighting classes to coffeescript', function () {
     assert($('.coffee.begin').length)
+  })
+
+  it('applies inline syntax highlighting classes to diffs', function () {
+    assert($('.diff.inserted').length)
+    assert($('.diff.deleted').length)
   })
 
   it('does not encode entities within code blocks', function () {


### PR DESCRIPTION
Yaks be shaved, this should take care of #64:

* The stock [highlights](https://github.com/atom/highlights) package we use for syntax highlighting doesn't include a grammar for diffs. Its existing grammars are mostly automatically converted from TextMate grammars, and TM _does_ have a diff one, so I converted it myself and published it to NPM as [atom-language-diff](https://www.npmjs.com/package/atom-language-diff), then added it as a dependency here.
* I discovered that the HTML sanitizer was wrecking the generated output. It turns out that the [highlights-tokens](https://www.npmjs.com/package/highlights-tokens) package, where we get a list of allowed class names, generates the token list by analyzing the `highlights` package's generated grammar objects. So I added a build step to `atom-language-diff` that generates a `tokens.json` we could use here. This PR pulls that into a separate module along with the stock `highlights-tokens` stuff so we can have a convenient place to add more in the future (**see note below**).
* That all seemed to work, so I added a couple of tests, and here we are.

**Note:** Unless I'm missing something, I believe the other non-stock languages we support for syntax highlighting (`atom-language-nginx`, `language-rust`, etc..) aren't going to make it past the sanitizing step without first going through a similar process of generating their lists of valid tokens. Those might be candidates for new Issues.