### PR TITLE
Wrap code blocks to match former output

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -45,8 +45,7 @@ module.exports = function (html, options) {
     }
   }
 
-  var parser = MD(mdOptions).use(lazyHeaders).use(emoji)
-  return parser.render(html)
+  return makeParser(mdOptions).render(html)
 }
 
 var mappings = {
@@ -74,4 +73,21 @@ function scopeNameFromLang (highlighter, lang) {
   // mappings[lang] = name
 
   return name
+}
+
+// create a parser instance, add plugins, update rules, etc...
+function makeParser (mdOptions) {
+  var parser = MD(mdOptions).use(lazyHeaders).use(emoji)
+
+  // monkey patch the 'fence' parsing rule to restore markdown-it's pre-5.1 behavior
+  // (see https://github.com/markdown-it/markdown-it/issues/190)
+  var stockFenceRule = parser.renderer.rules.fence
+  parser.renderer.rules.fence = function (tokens, idx, options, env, slf) {
+    // call the original rule first rather than inside the 'return' statement
+    // because we need the 'class' attribute processing it does
+    var output = stockFenceRule(tokens, idx, options, env, slf).trim()
+    return '<pre><code' + slf.renderAttrs(tokens[idx]) + '>' + output + '</code></pre>\n'
+  }
+
+  return parser
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "language-rust": "^0.4.3",
     "language-stylus": "^0.5.2",
     "lodash": "^3.10.1",
-    "markdown-it": "~5.0.2",
+    "markdown-it": "^5.1.0",
     "markdown-it-lazy-headers": "^0.1.3",
     "markdown-it-emoji": "^1.1.0",
     "property-ttl": "^1.0.0",


### PR DESCRIPTION
This fixes the tests reported broken in #90 due to a [change in renderer behavior in `markdown-it` 5.1.0](https://github.com/markdown-it/markdown-it/issues/190) by supplying a custom renderer rule that just wraps the output of the built in `fence` rule with `<pre><code class="...">...</code></pre>`. Discussion of the validity of nested `<pre>` elements aside, the effect is to restore the behavior from `markdown-it` 5.0.x as used here in `marky-markdown`.