### PR TITLE
Disable smiley shortcut handling in markdown-it-emoji

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -45,7 +45,7 @@ module.exports = function (html, options) {
     }
   }
 
-  var parser = MD(mdOptions).use(lazyHeaders).use(emoji)
+  var parser = MD(mdOptions).use(lazyHeaders).use(emoji, {shortcuts:{}})
   return parser.render(html)
 }
 

--- a/test/fixtures/github.md
+++ b/test/fixtures/github.md
@@ -34,4 +34,6 @@
 
 ### exchange.bind_headers(exchange, routing [, bindCallback])
 
+Smiley! :)
+
 :sparkles:

--- a/test/index.js
+++ b/test/index.js
@@ -104,6 +104,12 @@ describe('markdown processing and syntax highlighting', function () {
     var $ = marky(fixtures.github)
     assert($.html().indexOf('✨'))
   })
+
+  it('does not convert text emoticons to unicode', function () {
+    assert(~fixtures.github.indexOf(':)'))
+    var $ = marky(fixtures.github)
+    assert(~$.html().indexOf(':)'))
+  })
 })
 
 describe('sanitize', function () {


### PR DESCRIPTION
Here's a tiny PR that disables the "shortcut" handling in the `markdown-it-emoji` plugin we use for emoji support; fixes the issues pointed out as per #95.

This isn't directly compatible with #96 due to the rearranging I did there, but it's a pretty trivial modification to merge between the two; I'm happy to update whatever as needed.