### PR TITLE
Move re-scan function into separate function to avoid linter warning

### DIFF
--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -11,12 +11,15 @@ module.exports = function (grammars) {
     while (stops.length) stops.shift()()
   }
 
+  function runScan () {
+    scan()
+  }
+
   function scan () {
     while (managed < grammars.length - 1) {
       stops.push(
-        clean(grammars[managed], 'repository', 2000, function () {
-          scan() // start watching new grammars if they are added later.
-        }),
+        // start watching new grammars if they are added later.
+        clean(grammars[managed], 'repository', 2000, runScan),
         clean(grammars[managed++], 'initialRule', 2000)
       )
     }


### PR DESCRIPTION
For #71, since the linter is complaining that we shouldn't create a function in a loop.

My initial reaction is to just replace the anonymous function on line 17 with a reference to `scan`, but since technically the `clean()` function passes the time lived as a parameter to the callback, I decided it was (maybe?) clearer to make sure it's always called with an empty parameter list.