### PR TITLE
Update tests to support markdown-it 5.1.0

### DIFF
--- a/lib/code-wrap.js
+++ b/lib/code-wrap.js
@@ -1,0 +1,18 @@
+var plugin = module.exports = function (md, options) {
+  var tag = plugin.defaultTag
+  if (options && options.tag) {
+    tag = options.tag
+  }
+
+  // monkey patch the 'fence' parsing rule to restore markdown-it's pre-5.1 behavior
+  // (see https://github.com/markdown-it/markdown-it/issues/190)
+  var stockFenceRule = md.renderer.rules.fence
+  md.renderer.rules.fence = function (tokens, idx, options, env, slf) {
+    // call the original rule first rather than inside the 'return' statement
+    // because we need the 'class' attribute processing it does
+    var output = stockFenceRule(tokens, idx, options, env, slf).trim()
+    return '<' + tag + slf.renderAttrs(tokens[idx]) + '>' + output + '</' + tag + '>\n'
+  }
+}
+
+plugin.defaultTag = 'div'

--- a/lib/render.js
+++ b/lib/render.js
@@ -45,8 +45,7 @@ module.exports = function (html, options) {
     }
   }
 
-  var parser = MD(mdOptions).use(lazyHeaders).use(emoji, {shortcuts: {}})
-  return parser.render(html)
+  return makeParser(mdOptions).render(html)
 }
 
 var mappings = {
@@ -74,4 +73,21 @@ function scopeNameFromLang (highlighter, lang) {
   // mappings[lang] = name
 
   return name
+}
+
+// create a parser instance, add plugins, update rules, etc...
+function makeParser (mdOptions) {
+  var parser = MD(mdOptions).use(lazyHeaders).use(emoji, {shortcuts: {}})
+
+  // monkey patch the 'fence' parsing rule to restore markdown-it's pre-5.1 behavior
+  // (see https://github.com/markdown-it/markdown-it/issues/190)
+  var stockFenceRule = parser.renderer.rules.fence
+  parser.renderer.rules.fence = function (tokens, idx, options, env, slf) {
+    // call the original rule first rather than inside the 'return' statement
+    // because we need the 'class' attribute processing it does
+    var output = stockFenceRule(tokens, idx, options, env, slf).trim()
+    return '<div' + slf.renderAttrs(tokens[idx]) + '>' + output + '</div>\n'
+  }
+
+  return parser
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -4,6 +4,7 @@ var MD = require('markdown-it')
 var lazyHeaders = require('markdown-it-lazy-headers')
 var cleanup = require('./cleanup')
 var emoji = require('markdown-it-emoji')
+var codeWrap = require('./code-wrap')
 
 var highlighter = new Highlights()
 
@@ -45,7 +46,11 @@ module.exports = function (html, options) {
     }
   }
 
-  return makeParser(mdOptions).render(html)
+  var parser = MD(mdOptions)
+    .use(lazyHeaders)
+    .use(emoji, {shortcuts: {}})
+    .use(codeWrap)
+  return parser.render(html)
 }
 
 var mappings = {
@@ -73,21 +78,4 @@ function scopeNameFromLang (highlighter, lang) {
   // mappings[lang] = name
 
   return name
-}
-
-// create a parser instance, add plugins, update rules, etc...
-function makeParser (mdOptions) {
-  var parser = MD(mdOptions).use(lazyHeaders).use(emoji, {shortcuts: {}})
-
-  // monkey patch the 'fence' parsing rule to restore markdown-it's pre-5.1 behavior
-  // (see https://github.com/markdown-it/markdown-it/issues/190)
-  var stockFenceRule = parser.renderer.rules.fence
-  parser.renderer.rules.fence = function (tokens, idx, options, env, slf) {
-    // call the original rule first rather than inside the 'return' statement
-    // because we need the 'class' attribute processing it does
-    var output = stockFenceRule(tokens, idx, options, env, slf).trim()
-    return '<div' + slf.renderAttrs(tokens[idx]) + '>' + output + '</div>\n'
-  }
-
-  return parser
 }

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -8,7 +8,7 @@ sanitizer.config = {
     'del', 'div', 'h1', 'h2', 'iframe', 'img', 'ins', 'meta', 'pre', 's', 'span', 'sub', 'sup'
   ]),
   allowedClasses: {
-    code: [
+    div: [
       'highlight',
       'hljs',
       'bash',
@@ -22,12 +22,12 @@ sanitizer.config = {
       'javascript',
       'json',
       'lang-html',
+      'line',
       'sh',
       'shell',
       'typescript',
       'xml'
     ],
-    div: ['line'],
     h1: ['deep-link'],
     h2: ['deep-link'],
     h3: ['deep-link'],

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "language-rust": "^0.4.3",
     "language-stylus": "^0.5.2",
     "lodash": "^4.2.0",
-    "markdown-it": "~5.0.2",
+    "markdown-it": "^5.1.0",
     "markdown-it-lazy-headers": "^0.1.3",
     "markdown-it-emoji": "^1.1.0",
     "property-ttl": "^1.0.0",

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -17,31 +17,33 @@ describe('markdown processing and syntax highlighting', function () {
 
   it('converts github flavored fencing to code blocks', function () {
     assert(~fixtures.basic.indexOf('```js'))
-    assert($('code').length)
+    assert($('.highlight.js').length)
   })
 
   it('adds js class to javascript blocks', function () {
     assert(~fixtures.basic.indexOf('```js'))
-    assert($('code.js').length)
+    assert($('.highlight.js').length)
   })
 
   it('adds sh class to shell blocks', function () {
     assert(~fixtures.basic.indexOf('```sh'))
-    assert($('code.sh').length)
+    assert($('.highlight.sh').length)
   })
 
   it('adds coffeescript class to coffee blocks', function () {
     assert(~fixtures.basic.indexOf('```coffee'))
-    assert($('code.coffeescript').length)
+    assert($('.highlight.coffeescript').length)
   })
 
   it('adds diff class to diff blocks', function () {
     assert(~fixtures.basic.indexOf('```diff'))
-    assert($('code.diff').length)
+    assert($('.highlight.diff').length)
   })
 
-  it('adds highlight class to all blocks', function () {
-    assert.equal($('code').length, $('code.highlight').length)
+  it('wraps code highlighter output in div.highlight', function () {
+    // the idea here is that we have a 1:1 correspondence of <div class='highlight'>
+    // and their contained <pre class='editor'> elements coming from the highlighter
+    assert.equal($('div.highlight').length, $('div.highlight > pre.editor').length)
   })
 
   it('applies inline syntax highlighting classes to javascript', function () {

--- a/test/marky.js
+++ b/test/marky.js
@@ -70,7 +70,7 @@ describe('fixtures', function () {
 describe('debug', function () {
   it('produces the same output in debug mode as in normal mode', function () {
     // drop anything going to stdout (so we don't wreck mocha's console output)
-    var unhookIntercept = intercept(function () { return "" })
+    var unhookIntercept = intercept(function () { return '' })
 
     var $ = marky(fixtures.benchmark)
     var debug = marky(fixtures.benchmark, {debug: true})

--- a/test/sanitize.js
+++ b/test/sanitize.js
@@ -47,8 +47,8 @@ describe('sanitize', function () {
     assert(!$('.xxx').length)
   })
 
-  it('allows classnames on code tags', function () {
-    assert($('code.highlight').length)
+  it('allows classnames on div tags used for syntax highlighting', function () {
+    assert($('div.highlight').length)
   })
 
   it('allows the <s> strikethrough element', function () {


### PR DESCRIPTION
As of `markdown-it` 5.1.0, we no longer have a `<pre><code>...</code></pre>` wrapper on fenced code blocks; this PR updates the tests that fail as a result of that change, plus removes a couple that were specifically looking for `class="highlight"` on said `<code>` elements.

If/when this is merged, the root of the rendered code blocks will be `<pre class="editor">`, and lots of dependents' CSS will need updated.