### PR TITLE
Ignore package scope when calculating header/name similarity

### DIFF
--- a/lib/packagize.js
+++ b/lib/packagize.js
@@ -12,6 +12,7 @@ var packagize = module.exports = function ($, pkg) {
   var h1 = $('h1').first()
   if (
     similarity(pkg.name, h1.text()) > 0.6 ||
+    similarity(pkg.name.replace(/^@[^\/]+\//, ''), h1.text()) > 0.6 || // filter out scope name
     ~h1.text().toLowerCase().indexOf(pkg.name.toLowerCase())
   ) {
     h1.addClass('package-name-redundant')

--- a/test/fixtures/burblewibble.md
+++ b/test/fixtures/burblewibble.md
@@ -1,0 +1,5 @@
+# wibble
+
+A package called @burble/wibble!
+
+Here's another paragraph.

--- a/test/index.js
+++ b/test/index.js
@@ -393,12 +393,21 @@ describe('packagize', function () {
     dangledor: {
       name: 'dangledor',
       description: 'dangledor need not roar'
+    },
+    '@burble/wibble': {
+      name: '@burble/wibble',
+      description: 'A package called @burble/wibble!'
     }
   }
 
   describe('name', function () {
     it("adds .package-name-redundant class to first h1 if it's similar to package.name", function () {
       var $ = marky(fixtures.wibble, {package: packages.wibble})
+      assert.equal($('h1.package-name-redundant').length, 1)
+    })
+
+    it("adds .package-name-redundant class to first h1 if it's similar to a scoped package.name", function () {
+      var $ = marky(fixtures.burblewibble, {package: packages['@burble/wibble']})
       assert.equal($('h1.package-name-redundant').length, 1)
     })
 


### PR DESCRIPTION
I think the issue in #48 is that the similarity checker has no knowledge of scoped package names. If we add a line of code that does a regex match to filter out anything between a leading `@` and the first `/` (is that logic correct? Please double check my assumptions), then the packagizer code correctly applies `class='package-name-redundant'` to the generated H1.

I tested this against [@sindresorhus/df](https://www.npmjs.com/package/@sindresorhus/df) and [@aredridel/redis-mock](https://www.npmjs.com/package/@aredridel/redis-mock).