### PR TITLE
Update to lodash 4.0, handle its breaking changes

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -62,7 +62,7 @@ function scopeNameFromLang (highlighter, lang) {
 
   if (mappings[lang]) return mappings[lang]
 
-  var grammar = _.pick(highlighter.registry.grammarsByScopeName, function (val, key) {
+  var grammar = _.pickBy(highlighter.registry.grammarsByScopeName, function (val, key) {
     return val.name.toLowerCase() === lang
   })
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "language-ini": "^1.7.0",
     "language-rust": "^0.4.3",
     "language-stylus": "^0.5.2",
-    "lodash": "^3.10.1",
+    "lodash": "^4.0.0",
     "markdown-it": "~5.0.2",
     "markdown-it-lazy-headers": "^0.1.3",
     "markdown-it-emoji": "^1.1.0",


### PR DESCRIPTION
Apologies if I'm pushing ahead too quickly on this, but greenkeeper reported in #105 that switching to lodash 4 breaks the build; turns out all we need to do is call `_.pickBy()` rather than `_.pick()` when we're resolving languages in the code highlighting stuff.