### PR TITLE
Tighten up the YouTube filter regex

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -59,6 +59,6 @@ sanitizer.config = {
   exclusiveFilter: function (frame) {
     // Allow YouTube iframes
     if (frame.tag !== 'iframe') return false
-    return !String(frame.attribs.src).match(/\/\/(www\.)?youtube\.com/)
+    return !String(frame.attribs.src).match(/^(https?:)?\/\/(www\.)?youtube\.com/)
   }
 }

--- a/test/fixtures/basic.md
+++ b/test/fixtures/basic.md
@@ -42,4 +42,12 @@ alert "hi"
 
 <iframe src="//www.youtube.com/embed/3I78ELjTzlQ" frameborder="0" allowfullscreen></iframe>
 
+<iframe src="https://www.youtube.com/embed/DN4yLZB1vUQ"></iframe>
+
 <iframe src="//malware.com" allowfullscreen></iframe>
+
+<iframe src="http://malware.com/infect//www.youtube.com/embed/yWeAZEqNCXM" frameborder="0" allowfullscreen></iframe>
+
+<iframe src='delete-account#//youtube.com' />
+
+<iframe src='data:application,this is a malware containing the string //youtube.com' />

--- a/test/index.js
+++ b/test/index.js
@@ -168,8 +168,9 @@ describe('sanitize', function () {
     var $ = marky(fixtures.basic)
     assert(~fixtures.basic.indexOf('<iframe src="//www.youtube.com/embed/3I78ELjTzlQ'))
     assert(~fixtures.basic.indexOf('<iframe src="//malware.com'))
-    assert.equal($('iframe').length, 1)
-    assert.equal($('iframe').attr('src'), '//www.youtube.com/embed/3I78ELjTzlQ')
+    assert.equal($('iframe').length, 2)
+    assert.equal($('iframe').eq(0).attr('src'), '//www.youtube.com/embed/3I78ELjTzlQ')
+    assert.equal($('iframe').eq(1).attr('src'), 'https://www.youtube.com/embed/DN4yLZB1vUQ')
   })
 
   it('allows the <ins> element', function () {
@@ -355,27 +356,36 @@ describe('github', function () {
 
 describe('youtube', function () {
   var $
-  var iframe
+  var iframes
 
   before(function () {
     $ = marky(fixtures.basic)
-    iframe = $('.youtube-video > iframe')
+    iframes = $('.youtube-video > iframe')
   })
 
   it('wraps iframes in a div for stylability', function () {
     assert(!~fixtures.basic.indexOf('youtube-video'))
-    assert.equal(iframe.length, 1)
+    assert.equal(iframes.length, 2)
   })
 
   it('removes iframe width and height properties', function () {
+    var iframe = iframes.eq(0)
     assert.equal(iframe.attr('width'), null)
     assert.equal(iframe.attr('height'), null)
   })
 
-  it('preserves src, frameborder, and allowfullscreen properties', function () {
+  it('preserves existing src, frameborder, and allowfullscreen properties', function () {
+    var iframe = iframes.eq(0)
     assert.equal(iframe.attr('src'), '//www.youtube.com/embed/3I78ELjTzlQ')
     assert.equal(iframe.attr('frameborder'), '0')
     assert.equal(iframe.attr('allowfullscreen'), '')
+  })
+
+  it('preserves full src, does not add missing frameborder and allowfullscreen attributes', function () {
+    var iframe2 = iframes.eq(1)
+    assert.equal(iframe2.attr('src'), 'https://www.youtube.com/embed/DN4yLZB1vUQ')
+    assert.equal(typeof iframe2.attr('frameborder'), 'undefined')
+    assert.equal(typeof iframe2.attr('allowfullscreen'), 'undefined')
   })
 
 })


### PR DESCRIPTION
Prior to this commit, any URL containing "//youtube.com" would make it through our filter, but the intent was to only allow actual YouTube URLs. So now we're more explicit about requiring that "//youtube.com" either starts the string, or is preceded by "http:" or "https:". We've also got some test updates to make sure URLs previously wrongly allowed get filtered out, plus that a full URL where the "//" doesn't appear at the very beginning still works.

Fixes #108.