### PR TITLE
Overhaul devDependencies' readme parsing test strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,20 +52,9 @@
     "similarity": "^1.0.1"
   },
   "devDependencies": {
-    "async": "^0.9.0",
-    "benchmark": "^1.0.0",
-    "cicada": "~1.1.1",
-    "express": "^4.10.7",
     "glob": "^4.3.5",
-    "grunt-angular-templates": "^0.5.7",
-    "johnny-five": "^0.8.37",
-    "maintenance-modules": "1.0.2",
-    "memoize": "~0.1.1",
-    "mkhere": "~1.0.9",
     "mocha": "^2.0.1",
-    "payform": "1.0.1",
-    "standard": "^3.7.0",
-    "wzrd": "^1.1.1"
+    "standard": "^3.7.0"
   },
   "bin": "./bin/marky-markdown.js",
   "contributors": [

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,20 +1,25 @@
 var fs = require('fs')
 var path = require('path')
 var glob = require('glob')
-var fixtures = {}
+
+var fixtures = {
+  dependencies: [], // our dependencies and devDependencies
+  examples: [] // examples manually saved as fixtures
+}
 
 // Read in all the hand-written fixture files
 fs.readdirSync(__dirname + '/fixtures').forEach(function (file) {
   var key = path.basename(file).replace('.md', '')
-  fixtures[key] = fs.readFileSync(__dirname + '/fixtures/' + file).toString()
+  if (key !== path.basename(file)) { // skip anything lacking a .md extension
+    fixtures[key] = fs.readFileSync(__dirname + '/fixtures/' + file).toString()
+  }
 })
 
-// Read in all the devDependencies readmes
-fixtures.packageNames = Object.keys(require('../package.json').devDependencies)
+// Read in dependencies' and devDependencies' readmes
+fixtures.dependencies = Object.keys(require('../package.json').devDependencies)
   .concat(Object.keys(require('../package.json').dependencies))
   .sort()
-
-fixtures.packageNames.forEach(function (name) {
+fixtures.dependencies.forEach(function (name) {
   var modulePath = path.resolve('node_modules', name)
 
   // Find README.md, readme.md, README, readme.markdown, etc
@@ -26,5 +31,15 @@ fixtures.packageNames.forEach(function (name) {
   var readme = fs.readFileSync(path.resolve(modulePath, readmeFilename), 'utf-8')
   fixtures[name] = readme
 })
+
+// Read in all the sample readmes saved as fixtures
+fs.readdirSync(__dirname + '/fixtures/readmes').forEach(function (file) {
+  var key = path.basename(file).replace('.md', '')
+  if (key !== path.basename(file)) { // skip anything lacking a .md extension
+    fixtures[key] = fs.readFileSync(__dirname + '/fixtures/readmes/' + file).toString()
+    fixtures.examples.push(key)
+  }
+})
+fixtures.examples.sort()
 
 module.exports = fixtures

--- a/test/fixtures/readmes/async.md
+++ b/test/fixtures/readmes/async.md
@@ -1,0 +1,1647 @@
+# Async.js
+
+[![Build Status via Travis CI](https://travis-ci.org/caolan/async.svg?branch=master)](https://travis-ci.org/caolan/async)
+
+
+Async is a utility module which provides straight-forward, powerful functions
+for working with asynchronous JavaScript. Although originally designed for
+use with [Node.js](http://nodejs.org) and installable via `npm install async`,
+it can also be used directly in the browser.
+
+Async is also installable via:
+
+- [bower](http://bower.io/): `bower install async`
+- [component](https://github.com/component/component): `component install
+  caolan/async`
+- [jam](http://jamjs.org/): `jam install async`
+- [spm](http://spmjs.io/): `spm install async`
+
+Async provides around 20 functions that include the usual 'functional'
+suspects (`map`, `reduce`, `filter`, `each`…) as well as some common patterns
+for asynchronous control flow (`parallel`, `series`, `waterfall`…). All these
+functions assume you follow the Node.js convention of providing a single
+callback as the last argument of your `async` function.
+
+
+## Quick Examples
+
+```javascript
+async.map(['file1','file2','file3'], fs.stat, function(err, results){
+    // results is now an array of stats for each file
+});
+
+async.filter(['file1','file2','file3'], fs.exists, function(results){
+    // results now equals an array of the existing files
+});
+
+async.parallel([
+    function(){ ... },
+    function(){ ... }
+], callback);
+
+async.series([
+    function(){ ... },
+    function(){ ... }
+]);
+```
+
+There are many more functions available so take a look at the docs below for a
+full list. This module aims to be comprehensive, so if you feel anything is
+missing please create a GitHub issue for it.
+
+## Common Pitfalls
+
+### Binding a context to an iterator
+
+This section is really about `bind`, not about `async`. If you are wondering how to
+make `async` execute your iterators in a given context, or are confused as to why
+a method of another library isn't working as an iterator, study this example:
+
+```js
+// Here is a simple object with an (unnecessarily roundabout) squaring method
+var AsyncSquaringLibrary = {
+  squareExponent: 2,
+  square: function(number, callback){ 
+    var result = Math.pow(number, this.squareExponent);
+    setTimeout(function(){
+      callback(null, result);
+    }, 200);
+  }
+};
+
+async.map([1, 2, 3], AsyncSquaringLibrary.square, function(err, result){
+  // result is [NaN, NaN, NaN]
+  // This fails because the `this.squareExponent` expression in the square
+  // function is not evaluated in the context of AsyncSquaringLibrary, and is
+  // therefore undefined.
+});
+
+async.map([1, 2, 3], AsyncSquaringLibrary.square.bind(AsyncSquaringLibrary), function(err, result){
+  // result is [1, 4, 9]
+  // With the help of bind we can attach a context to the iterator before
+  // passing it to async. Now the square function will be executed in its 
+  // 'home' AsyncSquaringLibrary context and the value of `this.squareExponent`
+  // will be as expected.
+});
+```
+
+## Download
+
+The source is available for download from
+[GitHub](http://github.com/caolan/async).
+Alternatively, you can install using Node Package Manager (`npm`):
+
+    npm install async
+
+__Development:__ [async.js](https://github.com/caolan/async/raw/master/lib/async.js) - 29.6kb Uncompressed
+
+## In the Browser
+
+So far it's been tested in IE6, IE7, IE8, FF3.6 and Chrome 5. 
+
+Usage:
+
+```html
+<script type="text/javascript" src="async.js"></script>
+<script type="text/javascript">
+
+    async.map(data, asyncProcess, function(err, results){
+        alert(results);
+    });
+
+</script>
+```
+
+## Documentation
+
+### Collections
+
+* [`each`](#each)
+* [`eachSeries`](#eachSeries)
+* [`eachLimit`](#eachLimit)
+* [`map`](#map)
+* [`mapSeries`](#mapSeries)
+* [`mapLimit`](#mapLimit)
+* [`filter`](#filter)
+* [`filterSeries`](#filterSeries)
+* [`reject`](#reject)
+* [`rejectSeries`](#rejectSeries)
+* [`reduce`](#reduce)
+* [`reduceRight`](#reduceRight)
+* [`detect`](#detect)
+* [`detectSeries`](#detectSeries)
+* [`sortBy`](#sortBy)
+* [`some`](#some)
+* [`every`](#every)
+* [`concat`](#concat)
+* [`concatSeries`](#concatSeries)
+
+### Control Flow
+
+* [`series`](#seriestasks-callback)
+* [`parallel`](#parallel)
+* [`parallelLimit`](#parallellimittasks-limit-callback)
+* [`whilst`](#whilst)
+* [`doWhilst`](#doWhilst)
+* [`until`](#until)
+* [`doUntil`](#doUntil)
+* [`forever`](#forever)
+* [`waterfall`](#waterfall)
+* [`compose`](#compose)
+* [`seq`](#seq)
+* [`applyEach`](#applyEach)
+* [`applyEachSeries`](#applyEachSeries)
+* [`queue`](#queue)
+* [`priorityQueue`](#priorityQueue)
+* [`cargo`](#cargo)
+* [`auto`](#auto)
+* [`retry`](#retry)
+* [`iterator`](#iterator)
+* [`apply`](#apply)
+* [`nextTick`](#nextTick)
+* [`times`](#times)
+* [`timesSeries`](#timesSeries)
+
+### Utils
+
+* [`memoize`](#memoize)
+* [`unmemoize`](#unmemoize)
+* [`log`](#log)
+* [`dir`](#dir)
+* [`noConflict`](#noConflict)
+
+
+## Collections
+
+<a name="forEach" />
+<a name="each" />
+### each(arr, iterator, callback)
+
+Applies the function `iterator` to each item in `arr`, in parallel.
+The `iterator` is called with an item from the list, and a callback for when it
+has finished. If the `iterator` passes an error to its `callback`, the main
+`callback` (for the `each` function) is immediately called with the error.
+
+Note, that since this function applies `iterator` to each item in parallel,
+there is no guarantee that the iterator functions will complete in order.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `iterator(item, callback)` - A function to apply to each item in `arr`.
+  The iterator is passed a `callback(err)` which must be called once it has 
+  completed. If no error has occurred, the `callback` should be run without 
+  arguments or with an explicit `null` argument.
+* `callback(err)` - A callback which is called when all `iterator` functions
+  have finished, or an error occurs.
+
+__Examples__
+
+
+```js
+// assuming openFiles is an array of file names and saveFile is a function
+// to save the modified contents of that file:
+
+async.each(openFiles, saveFile, function(err){
+    // if any of the saves produced an error, err would equal that error
+});
+```
+
+```js
+// assuming openFiles is an array of file names 
+
+async.each(openFiles, function(file, callback) {
+  
+  // Perform operation on file here.
+  console.log('Processing file ' + file);
+  
+  if( file.length > 32 ) {
+    console.log('This file name is too long');
+    callback('File name too long');
+  } else {
+    // Do work to process file here
+    console.log('File processed');
+    callback();
+  }
+}, function(err){
+    // if any of the file processing produced an error, err would equal that error
+    if( err ) {
+      // One of the iterations produced an error.
+      // All processing will now stop.
+      console.log('A file failed to process');
+    } else {
+      console.log('All files have been processed successfully');
+    }
+});
+```
+
+---------------------------------------
+
+<a name="forEachSeries" />
+<a name="eachSeries" />
+### eachSeries(arr, iterator, callback)
+
+The same as [`each`](#each), only `iterator` is applied to each item in `arr` in
+series. The next `iterator` is only called once the current one has completed. 
+This means the `iterator` functions will complete in order.
+
+
+---------------------------------------
+
+<a name="forEachLimit" />
+<a name="eachLimit" />
+### eachLimit(arr, limit, iterator, callback)
+
+The same as [`each`](#each), only no more than `limit` `iterator`s will be simultaneously 
+running at any time.
+
+Note that the items in `arr` are not processed in batches, so there is no guarantee that 
+the first `limit` `iterator` functions will complete before any others are started.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `limit` - The maximum number of `iterator`s to run at any time.
+* `iterator(item, callback)` - A function to apply to each item in `arr`.
+  The iterator is passed a `callback(err)` which must be called once it has 
+  completed. If no error has occurred, the callback should be run without 
+  arguments or with an explicit `null` argument.
+* `callback(err)` - A callback which is called when all `iterator` functions
+  have finished, or an error occurs.
+
+__Example__
+
+```js
+// Assume documents is an array of JSON objects and requestApi is a
+// function that interacts with a rate-limited REST api.
+
+async.eachLimit(documents, 20, requestApi, function(err){
+    // if any of the saves produced an error, err would equal that error
+});
+```
+
+---------------------------------------
+
+<a name="map" />
+### map(arr, iterator, callback)
+
+Produces a new array of values by mapping each value in `arr` through
+the `iterator` function. The `iterator` is called with an item from `arr` and a
+callback for when it has finished processing. Each of these callback takes 2 arguments: 
+an `error`, and the transformed item from `arr`. If `iterator` passes an error to his 
+callback, the main `callback` (for the `map` function) is immediately called with the error.
+
+Note, that since this function applies the `iterator` to each item in parallel,
+there is no guarantee that the `iterator` functions will complete in order. 
+However, the results array will be in the same order as the original `arr`.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `iterator(item, callback)` - A function to apply to each item in `arr`.
+  The iterator is passed a `callback(err, transformed)` which must be called once 
+  it has completed with an error (which can be `null`) and a transformed item.
+* `callback(err, results)` - A callback which is called when all `iterator`
+  functions have finished, or an error occurs. Results is an array of the
+  transformed items from the `arr`.
+
+__Example__
+
+```js
+async.map(['file1','file2','file3'], fs.stat, function(err, results){
+    // results is now an array of stats for each file
+});
+```
+
+---------------------------------------
+
+<a name="mapSeries" />
+### mapSeries(arr, iterator, callback)
+
+The same as [`map`](#map), only the `iterator` is applied to each item in `arr` in
+series. The next `iterator` is only called once the current one has completed. 
+The results array will be in the same order as the original.
+
+
+---------------------------------------
+
+<a name="mapLimit" />
+### mapLimit(arr, limit, iterator, callback)
+
+The same as [`map`](#map), only no more than `limit` `iterator`s will be simultaneously 
+running at any time.
+
+Note that the items are not processed in batches, so there is no guarantee that 
+the first `limit` `iterator` functions will complete before any others are started.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `limit` - The maximum number of `iterator`s to run at any time.
+* `iterator(item, callback)` - A function to apply to each item in `arr`.
+  The iterator is passed a `callback(err, transformed)` which must be called once 
+  it has completed with an error (which can be `null`) and a transformed item.
+* `callback(err, results)` - A callback which is called when all `iterator`
+  calls have finished, or an error occurs. The result is an array of the
+  transformed items from the original `arr`.
+
+__Example__
+
+```js
+async.mapLimit(['file1','file2','file3'], 1, fs.stat, function(err, results){
+    // results is now an array of stats for each file
+});
+```
+
+---------------------------------------
+
+<a name="select" />
+<a name="filter" />
+### filter(arr, iterator, callback)
+
+__Alias:__ `select`
+
+Returns a new array of all the values in `arr` which pass an async truth test.
+_The callback for each `iterator` call only accepts a single argument of `true` or
+`false`; it does not accept an error argument first!_ This is in-line with the
+way node libraries work with truth tests like `fs.exists`. This operation is
+performed in parallel, but the results array will be in the same order as the
+original.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `iterator(item, callback)` - A truth test to apply to each item in `arr`.
+  The `iterator` is passed a `callback(truthValue)`, which must be called with a 
+  boolean argument once it has completed.
+* `callback(results)` - A callback which is called after all the `iterator`
+  functions have finished.
+
+__Example__
+
+```js
+async.filter(['file1','file2','file3'], fs.exists, function(results){
+    // results now equals an array of the existing files
+});
+```
+
+---------------------------------------
+
+<a name="selectSeries" />
+<a name="filterSeries" />
+### filterSeries(arr, iterator, callback)
+
+__Alias:__ `selectSeries`
+
+The same as [`filter`](#filter) only the `iterator` is applied to each item in `arr` in
+series. The next `iterator` is only called once the current one has completed. 
+The results array will be in the same order as the original.
+
+---------------------------------------
+
+<a name="reject" />
+### reject(arr, iterator, callback)
+
+The opposite of [`filter`](#filter). Removes values that pass an `async` truth test.
+
+---------------------------------------
+
+<a name="rejectSeries" />
+### rejectSeries(arr, iterator, callback)
+
+The same as [`reject`](#reject), only the `iterator` is applied to each item in `arr`
+in series.
+
+
+---------------------------------------
+
+<a name="reduce" />
+### reduce(arr, memo, iterator, callback)
+
+__Aliases:__ `inject`, `foldl`
+
+Reduces `arr` into a single value using an async `iterator` to return
+each successive step. `memo` is the initial state of the reduction. 
+This function only operates in series. 
+
+For performance reasons, it may make sense to split a call to this function into 
+a parallel map, and then use the normal `Array.prototype.reduce` on the results. 
+This function is for situations where each step in the reduction needs to be async; 
+if you can get the data before reducing it, then it's probably a good idea to do so.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `memo` - The initial state of the reduction.
+* `iterator(memo, item, callback)` - A function applied to each item in the
+  array to produce the next step in the reduction. The `iterator` is passed a
+  `callback(err, reduction)` which accepts an optional error as its first 
+  argument, and the state of the reduction as the second. If an error is 
+  passed to the callback, the reduction is stopped and the main `callback` is 
+  immediately called with the error.
+* `callback(err, result)` - A callback which is called after all the `iterator`
+  functions have finished. Result is the reduced value.
+
+__Example__
+
+```js
+async.reduce([1,2,3], 0, function(memo, item, callback){
+    // pointless async:
+    process.nextTick(function(){
+        callback(null, memo + item)
+    });
+}, function(err, result){
+    // result is now equal to the last value of memo, which is 6
+});
+```
+
+---------------------------------------
+
+<a name="reduceRight" />
+### reduceRight(arr, memo, iterator, callback)
+
+__Alias:__ `foldr`
+
+Same as [`reduce`](#reduce), only operates on `arr` in reverse order.
+
+
+---------------------------------------
+
+<a name="detect" />
+### detect(arr, iterator, callback)
+
+Returns the first value in `arr` that passes an async truth test. The
+`iterator` is applied in parallel, meaning the first iterator to return `true` will
+fire the detect `callback` with that result. That means the result might not be
+the first item in the original `arr` (in terms of order) that passes the test.
+
+If order within the original `arr` is important, then look at [`detectSeries`](#detectSeries).
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `iterator(item, callback)` - A truth test to apply to each item in `arr`.
+  The iterator is passed a `callback(truthValue)` which must be called with a 
+  boolean argument once it has completed.
+* `callback(result)` - A callback which is called as soon as any iterator returns
+  `true`, or after all the `iterator` functions have finished. Result will be
+  the first item in the array that passes the truth test (iterator) or the
+  value `undefined` if none passed.
+
+__Example__
+
+```js
+async.detect(['file1','file2','file3'], fs.exists, function(result){
+    // result now equals the first file in the list that exists
+});
+```
+
+---------------------------------------
+
+<a name="detectSeries" />
+### detectSeries(arr, iterator, callback)
+
+The same as [`detect`](#detect), only the `iterator` is applied to each item in `arr`
+in series. This means the result is always the first in the original `arr` (in
+terms of array order) that passes the truth test.
+
+
+---------------------------------------
+
+<a name="sortBy" />
+### sortBy(arr, iterator, callback)
+
+Sorts a list by the results of running each `arr` value through an async `iterator`.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `iterator(item, callback)` - A function to apply to each item in `arr`.
+  The iterator is passed a `callback(err, sortValue)` which must be called once it
+  has completed with an error (which can be `null`) and a value to use as the sort
+  criteria.
+* `callback(err, results)` - A callback which is called after all the `iterator`
+  functions have finished, or an error occurs. Results is the items from
+  the original `arr` sorted by the values returned by the `iterator` calls.
+
+__Example__
+
+```js
+async.sortBy(['file1','file2','file3'], function(file, callback){
+    fs.stat(file, function(err, stats){
+        callback(err, stats.mtime);
+    });
+}, function(err, results){
+    // results is now the original array of files sorted by
+    // modified date
+});
+```
+
+__Sort Order__
+
+By modifying the callback parameter the sorting order can be influenced:
+
+```js
+//ascending order
+async.sortBy([1,9,3,5], function(x, callback){
+    callback(null, x);
+}, function(err,result){
+    //result callback
+} );
+
+//descending order
+async.sortBy([1,9,3,5], function(x, callback){
+    callback(null, x*-1);    //<- x*-1 instead of x, turns the order around
+}, function(err,result){
+    //result callback
+} );
+```
+
+---------------------------------------
+
+<a name="some" />
+### some(arr, iterator, callback)
+
+__Alias:__ `any`
+
+Returns `true` if at least one element in the `arr` satisfies an async test.
+_The callback for each iterator call only accepts a single argument of `true` or
+`false`; it does not accept an error argument first!_ This is in-line with the
+way node libraries work with truth tests like `fs.exists`. Once any iterator
+call returns `true`, the main `callback` is immediately called.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `iterator(item, callback)` - A truth test to apply to each item in the array
+  in parallel. The iterator is passed a callback(truthValue) which must be 
+  called with a boolean argument once it has completed.
+* `callback(result)` - A callback which is called as soon as any iterator returns
+  `true`, or after all the iterator functions have finished. Result will be
+  either `true` or `false` depending on the values of the async tests.
+
+__Example__
+
+```js
+async.some(['file1','file2','file3'], fs.exists, function(result){
+    // if result is true then at least one of the files exists
+});
+```
+
+---------------------------------------
+
+<a name="every" />
+### every(arr, iterator, callback)
+
+__Alias:__ `all`
+
+Returns `true` if every element in `arr` satisfies an async test.
+_The callback for each `iterator` call only accepts a single argument of `true` or
+`false`; it does not accept an error argument first!_ This is in-line with the
+way node libraries work with truth tests like `fs.exists`.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `iterator(item, callback)` - A truth test to apply to each item in the array
+  in parallel. The iterator is passed a callback(truthValue) which must be 
+  called with a  boolean argument once it has completed.
+* `callback(result)` - A callback which is called after all the `iterator`
+  functions have finished. Result will be either `true` or `false` depending on
+  the values of the async tests.
+
+__Example__
+
+```js
+async.every(['file1','file2','file3'], fs.exists, function(result){
+    // if result is true then every file exists
+});
+```
+
+---------------------------------------
+
+<a name="concat" />
+### concat(arr, iterator, callback)
+
+Applies `iterator` to each item in `arr`, concatenating the results. Returns the
+concatenated list. The `iterator`s are called in parallel, and the results are
+concatenated as they return. There is no guarantee that the results array will
+be returned in the original order of `arr` passed to the `iterator` function.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `iterator(item, callback)` - A function to apply to each item in `arr`.
+  The iterator is passed a `callback(err, results)` which must be called once it 
+  has completed with an error (which can be `null`) and an array of results.
+* `callback(err, results)` - A callback which is called after all the `iterator`
+  functions have finished, or an error occurs. Results is an array containing
+  the concatenated results of the `iterator` function.
+
+__Example__
+
+```js
+async.concat(['dir1','dir2','dir3'], fs.readdir, function(err, files){
+    // files is now a list of filenames that exist in the 3 directories
+});
+```
+
+---------------------------------------
+
+<a name="concatSeries" />
+### concatSeries(arr, iterator, callback)
+
+Same as [`concat`](#concat), but executes in series instead of parallel.
+
+
+## Control Flow
+
+<a name="series" />
+### series(tasks, [callback])
+
+Run the functions in the `tasks` array in series, each one running once the previous
+function has completed. If any functions in the series pass an error to its
+callback, no more functions are run, and `callback` is immediately called with the value of the error. 
+Otherwise, `callback` receives an array of results when `tasks` have completed.
+
+It is also possible to use an object instead of an array. Each property will be
+run as a function, and the results will be passed to the final `callback` as an object
+instead of an array. This can be a more readable way of handling results from
+[`series`](#series).
+
+**Note** that while many implementations preserve the order of object properties, the
+[ECMAScript Language Specifcation](http://www.ecma-international.org/ecma-262/5.1/#sec-8.6) 
+explicitly states that
+
+> The mechanics and order of enumerating the properties is not specified.
+
+So if you rely on the order in which your series of functions are executed, and want
+this to work on all platforms, consider using an array. 
+
+__Arguments__
+
+* `tasks` - An array or object containing functions to run, each function is passed
+  a `callback(err, result)` it must call on completion with an error `err` (which can
+  be `null`) and an optional `result` value.
+* `callback(err, results)` - An optional callback to run once all the functions
+  have completed. This function gets a results array (or object) containing all 
+  the result arguments passed to the `task` callbacks.
+
+__Example__
+
+```js
+async.series([
+    function(callback){
+        // do some stuff ...
+        callback(null, 'one');
+    },
+    function(callback){
+        // do some more stuff ...
+        callback(null, 'two');
+    }
+],
+// optional callback
+function(err, results){
+    // results is now equal to ['one', 'two']
+});
+
+
+// an example using an object instead of an array
+async.series({
+    one: function(callback){
+        setTimeout(function(){
+            callback(null, 1);
+        }, 200);
+    },
+    two: function(callback){
+        setTimeout(function(){
+            callback(null, 2);
+        }, 100);
+    }
+},
+function(err, results) {
+    // results is now equal to: {one: 1, two: 2}
+});
+```
+
+---------------------------------------
+
+<a name="parallel" />
+### parallel(tasks, [callback])
+
+Run the `tasks` array of functions in parallel, without waiting until the previous
+function has completed. If any of the functions pass an error to its
+callback, the main `callback` is immediately called with the value of the error.
+Once the `tasks` have completed, the results are passed to the final `callback` as an
+array.
+
+It is also possible to use an object instead of an array. Each property will be
+run as a function and the results will be passed to the final `callback` as an object
+instead of an array. This can be a more readable way of handling results from
+[`parallel`](#parallel).
+
+
+__Arguments__
+
+* `tasks` - An array or object containing functions to run. Each function is passed 
+  a `callback(err, result)` which it must call on completion with an error `err` 
+  (which can be `null`) and an optional `result` value.
+* `callback(err, results)` - An optional callback to run once all the functions
+  have completed. This function gets a results array (or object) containing all 
+  the result arguments passed to the task callbacks.
+
+__Example__
+
+```js
+async.parallel([
+    function(callback){
+        setTimeout(function(){
+            callback(null, 'one');
+        }, 200);
+    },
+    function(callback){
+        setTimeout(function(){
+            callback(null, 'two');
+        }, 100);
+    }
+],
+// optional callback
+function(err, results){
+    // the results array will equal ['one','two'] even though
+    // the second function had a shorter timeout.
+});
+
+
+// an example using an object instead of an array
+async.parallel({
+    one: function(callback){
+        setTimeout(function(){
+            callback(null, 1);
+        }, 200);
+    },
+    two: function(callback){
+        setTimeout(function(){
+            callback(null, 2);
+        }, 100);
+    }
+},
+function(err, results) {
+    // results is now equals to: {one: 1, two: 2}
+});
+```
+
+---------------------------------------
+
+<a name="parallelLimit" />
+### parallelLimit(tasks, limit, [callback])
+
+The same as [`parallel`](#parallel), only `tasks` are executed in parallel 
+with a maximum of `limit` tasks executing at any time.
+
+Note that the `tasks` are not executed in batches, so there is no guarantee that 
+the first `limit` tasks will complete before any others are started.
+
+__Arguments__
+
+* `tasks` - An array or object containing functions to run, each function is passed 
+  a `callback(err, result)` it must call on completion with an error `err` (which can
+  be `null`) and an optional `result` value.
+* `limit` - The maximum number of `tasks` to run at any time.
+* `callback(err, results)` - An optional callback to run once all the functions
+  have completed. This function gets a results array (or object) containing all 
+  the result arguments passed to the `task` callbacks.
+
+---------------------------------------
+
+<a name="whilst" />
+### whilst(test, fn, callback)
+
+Repeatedly call `fn`, while `test` returns `true`. Calls `callback` when stopped,
+or an error occurs.
+
+__Arguments__
+
+* `test()` - synchronous truth test to perform before each execution of `fn`.
+* `fn(callback)` - A function which is called each time `test` passes. The function is
+  passed a `callback(err)`, which must be called once it has completed with an 
+  optional `err` argument.
+* `callback(err)` - A callback which is called after the test fails and repeated
+  execution of `fn` has stopped.
+
+__Example__
+
+```js
+var count = 0;
+
+async.whilst(
+    function () { return count < 5; },
+    function (callback) {
+        count++;
+        setTimeout(callback, 1000);
+    },
+    function (err) {
+        // 5 seconds have passed
+    }
+);
+```
+
+---------------------------------------
+
+<a name="doWhilst" />
+### doWhilst(fn, test, callback)
+
+The post-check version of [`whilst`](#whilst). To reflect the difference in 
+the order of operations, the arguments `test` and `fn` are switched. 
+
+`doWhilst` is to `whilst` as `do while` is to `while` in plain JavaScript.
+
+---------------------------------------
+
+<a name="until" />
+### until(test, fn, callback)
+
+Repeatedly call `fn` until `test` returns `true`. Calls `callback` when stopped,
+or an error occurs.
+
+The inverse of [`whilst`](#whilst).
+
+---------------------------------------
+
+<a name="doUntil" />
+### doUntil(fn, test, callback)
+
+Like [`doWhilst`](#doWhilst), except the `test` is inverted. Note the argument ordering differs from `until`.
+
+---------------------------------------
+
+<a name="forever" />
+### forever(fn, errback)
+
+Calls the asynchronous function `fn` with a callback parameter that allows it to
+call itself again, in series, indefinitely.
+
+If an error is passed to the callback then `errback` is called with the
+error, and execution stops, otherwise it will never be called.
+
+```js
+async.forever(
+    function(next) {
+        // next is suitable for passing to things that need a callback(err [, whatever]);
+        // it will result in this function being called again.
+    },
+    function(err) {
+        // if next is called with a value in its first parameter, it will appear
+        // in here as 'err', and execution will stop.
+    }
+);
+```
+
+---------------------------------------
+
+<a name="waterfall" />
+### waterfall(tasks, [callback])
+
+Runs the `tasks` array of functions in series, each passing their results to the next in
+the array. However, if any of the `tasks` pass an error to their own callback, the
+next function is not executed, and the main `callback` is immediately called with
+the error.
+
+__Arguments__
+
+* `tasks` - An array of functions to run, each function is passed a 
+  `callback(err, result1, result2, ...)` it must call on completion. The first
+  argument is an error (which can be `null`) and any further arguments will be 
+  passed as arguments in order to the next task.
+* `callback(err, [results])` - An optional callback to run once all the functions
+  have completed. This will be passed the results of the last task's callback.
+
+
+
+__Example__
+
+```js
+async.waterfall([
+    function(callback) {
+        callback(null, 'one', 'two');
+    },
+    function(arg1, arg2, callback) {
+      // arg1 now equals 'one' and arg2 now equals 'two'
+        callback(null, 'three');
+    },
+    function(arg1, callback) {
+        // arg1 now equals 'three'
+        callback(null, 'done');
+    }
+], function (err, result) {
+    // result now equals 'done'    
+});
+```
+
+---------------------------------------
+<a name="compose" />
+### compose(fn1, fn2...)
+
+Creates a function which is a composition of the passed asynchronous
+functions. Each function consumes the return value of the function that
+follows. Composing functions `f()`, `g()`, and `h()` would produce the result of
+`f(g(h()))`, only this version uses callbacks to obtain the return values.
+
+Each function is executed with the `this` binding of the composed function.
+
+__Arguments__
+
+* `functions...` - the asynchronous functions to compose
+
+
+__Example__
+
+```js
+function add1(n, callback) {
+    setTimeout(function () {
+        callback(null, n + 1);
+    }, 10);
+}
+
+function mul3(n, callback) {
+    setTimeout(function () {
+        callback(null, n * 3);
+    }, 10);
+}
+
+var add1mul3 = async.compose(mul3, add1);
+
+add1mul3(4, function (err, result) {
+   // result now equals 15
+});
+```
+
+---------------------------------------
+<a name="seq" />
+### seq(fn1, fn2...)
+
+Version of the compose function that is more natural to read.
+Each function consumes the return value of the previous function.
+It is the equivalent of [`compose`](#compose) with the arguments reversed.
+
+Each function is executed with the `this` binding of the composed function.
+
+__Arguments__
+
+* functions... - the asynchronous functions to compose
+
+
+__Example__
+
+```js
+// Requires lodash (or underscore), express3 and dresende's orm2.
+// Part of an app, that fetches cats of the logged user.
+// This example uses `seq` function to avoid overnesting and error 
+// handling clutter.
+app.get('/cats', function(request, response) {
+  var User = request.models.User;
+  async.seq(
+    _.bind(User.get, User),  // 'User.get' has signature (id, callback(err, data))
+    function(user, fn) {
+      user.getCats(fn);      // 'getCats' has signature (callback(err, data))
+    }
+  )(req.session.user_id, function (err, cats) {
+    if (err) {
+      console.error(err);
+      response.json({ status: 'error', message: err.message });
+    } else {
+      response.json({ status: 'ok', message: 'Cats found', data: cats });
+    }
+  });
+});
+```
+
+---------------------------------------
+<a name="applyEach" />
+### applyEach(fns, args..., callback)
+
+Applies the provided arguments to each function in the array, calling 
+`callback` after all functions have completed. If you only provide the first
+argument, then it will return a function which lets you pass in the
+arguments as if it were a single function call.
+
+__Arguments__
+
+* `fns` - the asynchronous functions to all call with the same arguments
+* `args...` - any number of separate arguments to pass to the function
+* `callback` - the final argument should be the callback, called when all
+  functions have completed processing
+
+
+__Example__
+
+```js
+async.applyEach([enableSearch, updateSchema], 'bucket', callback);
+
+// partial application example:
+async.each(
+    buckets,
+    async.applyEach([enableSearch, updateSchema]),
+    callback
+);
+```
+
+---------------------------------------
+
+<a name="applyEachSeries" />
+### applyEachSeries(arr, iterator, callback)
+
+The same as [`applyEach`](#applyEach) only the functions are applied in series.
+
+---------------------------------------
+
+<a name="queue" />
+### queue(worker, concurrency)
+
+Creates a `queue` object with the specified `concurrency`. Tasks added to the
+`queue` are processed in parallel (up to the `concurrency` limit). If all
+`worker`s are in progress, the task is queued until one becomes available. 
+Once a `worker` completes a `task`, that `task`'s callback is called.
+
+__Arguments__
+
+* `worker(task, callback)` - An asynchronous function for processing a queued
+  task, which must call its `callback(err)` argument when finished, with an 
+  optional `error` as an argument.
+* `concurrency` - An `integer` for determining how many `worker` functions should be
+  run in parallel.
+
+__Queue objects__
+
+The `queue` object returned by this function has the following properties and
+methods:
+
+* `length()` - a function returning the number of items waiting to be processed.
+* `started` - a function returning whether or not any items have been pushed and processed by the queue
+* `running()` - a function returning the number of items currently being processed.
+* `idle()` - a function returning false if there are items waiting or being processed, or true if not.
+* `concurrency` - an integer for determining how many `worker` functions should be
+  run in parallel. This property can be changed after a `queue` is created to
+  alter the concurrency on-the-fly.
+* `push(task, [callback])` - add a new task to the `queue`. Calls `callback` once 
+  the `worker` has finished processing the task. Instead of a single task, a `tasks` array
+  can be submitted. The respective callback is used for every task in the list.
+* `unshift(task, [callback])` - add a new task to the front of the `queue`.
+* `saturated` - a callback that is called when the `queue` length hits the `concurrency` limit, 
+   and further tasks will be queued.
+* `empty` - a callback that is called when the last item from the `queue` is given to a `worker`.
+* `drain` - a callback that is called when the last item from the `queue` has returned from the `worker`.
+* `paused` - a boolean for determining whether the queue is in a paused state
+* `pause()` - a function that pauses the processing of tasks until `resume()` is called.
+* `resume()` - a function that resumes the processing of queued tasks when the queue is paused.
+* `kill()` - a function that removes the `drain` callback and empties remaining tasks from the queue forcing it to go idle.
+
+__Example__
+
+```js
+// create a queue object with concurrency 2
+
+var q = async.queue(function (task, callback) {
+    console.log('hello ' + task.name);
+    callback();
+}, 2);
+
+
+// assign a callback
+q.drain = function() {
+    console.log('all items have been processed');
+}
+
+// add some items to the queue
+
+q.push({name: 'foo'}, function (err) {
+    console.log('finished processing foo');
+});
+q.push({name: 'bar'}, function (err) {
+    console.log('finished processing bar');
+});
+
+// add some items to the queue (batch-wise)
+
+q.push([{name: 'baz'},{name: 'bay'},{name: 'bax'}], function (err) {
+    console.log('finished processing item');
+});
+
+// add some items to the front of the queue
+
+q.unshift({name: 'bar'}, function (err) {
+    console.log('finished processing bar');
+});
+```
+
+
+---------------------------------------
+
+<a name="priorityQueue" />
+### priorityQueue(worker, concurrency)
+
+The same as [`queue`](#queue) only tasks are assigned a priority and completed in ascending priority order. There are two differences between `queue` and `priorityQueue` objects:
+
+* `push(task, priority, [callback])` - `priority` should be a number. If an array of
+  `tasks` is given, all tasks will be assigned the same priority.
+* The `unshift` method was removed.
+
+---------------------------------------
+
+<a name="cargo" />
+### cargo(worker, [payload])
+
+Creates a `cargo` object with the specified payload. Tasks added to the
+cargo will be processed altogether (up to the `payload` limit). If the
+`worker` is in progress, the task is queued until it becomes available. Once
+the `worker` has completed some tasks, each callback of those tasks is called.
+Check out [this animation](https://camo.githubusercontent.com/6bbd36f4cf5b35a0f11a96dcd2e97711ffc2fb37/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f313637363837312f36383130382f62626330636662302d356632392d313165322d393734662d3333393763363464633835382e676966) for how `cargo` and `queue` work.
+
+While [queue](#queue) passes only one task to one of a group of workers
+at a time, cargo passes an array of tasks to a single worker, repeating
+when the worker is finished.
+
+__Arguments__
+
+* `worker(tasks, callback)` - An asynchronous function for processing an array of
+  queued tasks, which must call its `callback(err)` argument when finished, with 
+  an optional `err` argument.
+* `payload` - An optional `integer` for determining how many tasks should be
+  processed per round; if omitted, the default is unlimited.
+
+__Cargo objects__
+
+The `cargo` object returned by this function has the following properties and
+methods:
+
+* `length()` - A function returning the number of items waiting to be processed.
+* `payload` - An `integer` for determining how many tasks should be
+  process per round. This property can be changed after a `cargo` is created to
+  alter the payload on-the-fly.
+* `push(task, [callback])` - Adds `task` to the `queue`. The callback is called
+  once the `worker` has finished processing the task. Instead of a single task, an array of `tasks` 
+  can be submitted. The respective callback is used for every task in the list.
+* `saturated` - A callback that is called when the `queue.length()` hits the concurrency and further tasks will be queued.
+* `empty` - A callback that is called when the last item from the `queue` is given to a `worker`.
+* `drain` - A callback that is called when the last item from the `queue` has returned from the `worker`.
+
+__Example__
+
+```js
+// create a cargo object with payload 2
+
+var cargo = async.cargo(function (tasks, callback) {
+    for(var i=0; i<tasks.length; i++){
+      console.log('hello ' + tasks[i].name);
+    }
+    callback();
+}, 2);
+
+
+// add some items
+
+cargo.push({name: 'foo'}, function (err) {
+    console.log('finished processing foo');
+});
+cargo.push({name: 'bar'}, function (err) {
+    console.log('finished processing bar');
+});
+cargo.push({name: 'baz'}, function (err) {
+    console.log('finished processing baz');
+});
+```
+
+---------------------------------------
+
+<a name="auto" />
+### auto(tasks, [callback])
+
+Determines the best order for running the functions in `tasks`, based on their 
+requirements. Each function can optionally depend on other functions being completed 
+first, and each function is run as soon as its requirements are satisfied. 
+
+If any of the functions pass an error to their callback, it will not 
+complete (so any other functions depending on it will not run), and the main 
+`callback` is immediately called with the error. Functions also receive an 
+object containing the results of functions which have completed so far.
+
+Note, all functions are called with a `results` object as a second argument, 
+so it is unsafe to pass functions in the `tasks` object which cannot handle the
+extra argument. 
+
+For example, this snippet of code:
+
+```js
+async.auto({
+  readData: async.apply(fs.readFile, 'data.txt', 'utf-8')
+}, callback);
+```
+
+will have the effect of calling `readFile` with the results object as the last
+argument, which will fail:
+
+```js
+fs.readFile('data.txt', 'utf-8', cb, {});
+```
+
+Instead, wrap the call to `readFile` in a function which does not forward the 
+`results` object:
+
+```js
+async.auto({
+  readData: function(cb, results){
+    fs.readFile('data.txt', 'utf-8', cb);
+  }
+}, callback);
+```
+
+__Arguments__
+
+* `tasks` - An object. Each of its properties is either a function or an array of
+  requirements, with the function itself the last item in the array. The object's key
+  of a property serves as the name of the task defined by that property,
+  i.e. can be used when specifying requirements for other tasks.
+  The function receives two arguments: (1) a `callback(err, result)` which must be 
+  called when finished, passing an `error` (which can be `null`) and the result of 
+  the function's execution, and (2) a `results` object, containing the results of
+  the previously executed functions.
+* `callback(err, results)` - An optional callback which is called when all the
+  tasks have been completed. It receives the `err` argument if any `tasks` 
+  pass an error to their callback. Results are always returned; however, if 
+  an error occurs, no further `tasks` will be performed, and the results
+  object will only contain partial results.
+
+
+__Example__
+
+```js
+async.auto({
+    get_data: function(callback){
+        console.log('in get_data');
+        // async code to get some data
+        callback(null, 'data', 'converted to array');
+    },
+    make_folder: function(callback){
+        console.log('in make_folder');
+        // async code to create a directory to store a file in
+        // this is run at the same time as getting the data
+        callback(null, 'folder');
+    },
+    write_file: ['get_data', 'make_folder', function(callback, results){
+        console.log('in write_file', JSON.stringify(results));
+        // once there is some data and the directory exists,
+        // write the data to a file in the directory
+        callback(null, 'filename');
+    }],
+    email_link: ['write_file', function(callback, results){
+        console.log('in email_link', JSON.stringify(results));
+        // once the file is written let's email a link to it...
+        // results.write_file contains the filename returned by write_file.
+        callback(null, {'file':results.write_file, 'email':'user@example.com'});
+    }]
+}, function(err, results) {
+    console.log('err = ', err);
+    console.log('results = ', results);
+});
+```
+
+This is a fairly trivial example, but to do this using the basic parallel and
+series functions would look like this:
+
+```js
+async.parallel([
+    function(callback){
+        console.log('in get_data');
+        // async code to get some data
+        callback(null, 'data', 'converted to array');
+    },
+    function(callback){
+        console.log('in make_folder');
+        // async code to create a directory to store a file in
+        // this is run at the same time as getting the data
+        callback(null, 'folder');
+    }
+],
+function(err, results){
+    async.series([
+        function(callback){
+            console.log('in write_file', JSON.stringify(results));
+            // once there is some data and the directory exists,
+            // write the data to a file in the directory
+            results.push('filename');
+            callback(null);
+        },
+        function(callback){
+            console.log('in email_link', JSON.stringify(results));
+            // once the file is written let's email a link to it...
+            callback(null, {'file':results.pop(), 'email':'user@example.com'});
+        }
+    ]);
+});
+```
+
+For a complicated series of `async` tasks, using the [`auto`](#auto) function makes adding
+new tasks much easier (and the code more readable).
+
+
+---------------------------------------
+
+<a name="retry" />
+### retry([times = 5], task, [callback])
+
+Attempts to get a successful response from `task` no more than `times` times before
+returning an error. If the task is successful, the `callback` will be passed the result
+of the successful task. If all attempts fail, the callback will be passed the error and
+result (if any) of the final attempt.
+
+__Arguments__
+
+* `times` - An integer indicating how many times to attempt the `task` before giving up. Defaults to 5.
+* `task(callback, results)` - A function which receives two arguments: (1) a `callback(err, result)`
+  which must be called when finished, passing `err` (which can be `null`) and the `result` of 
+  the function's execution, and (2) a `results` object, containing the results of
+  the previously executed functions (if nested inside another control flow).
+* `callback(err, results)` - An optional callback which is called when the
+  task has succeeded, or after the final failed attempt. It receives the `err` and `result` arguments of the last attempt at completing the `task`.
+
+The [`retry`](#retry) function can be used as a stand-alone control flow by passing a
+callback, as shown below:
+
+```js
+async.retry(3, apiMethod, function(err, result) {
+    // do something with the result
+});
+```
+
+It can also be embeded within other control flow functions to retry individual methods
+that are not as reliable, like this:
+
+```js
+async.auto({
+    users: api.getUsers.bind(api),
+    payments: async.retry(3, api.getPayments.bind(api))
+}, function(err, results) {
+  // do something with the results
+});
+```
+
+
+---------------------------------------
+
+<a name="iterator" />
+### iterator(tasks)
+
+Creates an iterator function which calls the next function in the `tasks` array,
+returning a continuation to call the next one after that. It's also possible to
+“peek” at the next iterator with `iterator.next()`.
+
+This function is used internally by the `async` module, but can be useful when
+you want to manually control the flow of functions in series.
+
+__Arguments__
+
+* `tasks` - An array of functions to run.
+
+__Example__
+
+```js
+var iterator = async.iterator([
+    function(){ sys.p('one'); },
+    function(){ sys.p('two'); },
+    function(){ sys.p('three'); }
+]);
+
+node> var iterator2 = iterator();
+'one'
+node> var iterator3 = iterator2();
+'two'
+node> iterator3();
+'three'
+node> var nextfn = iterator2.next();
+node> nextfn();
+'three'
+```
+
+---------------------------------------
+
+<a name="apply" />
+### apply(function, arguments..)
+
+Creates a continuation function with some arguments already applied. 
+
+Useful as a shorthand when combined with other control flow functions. Any arguments
+passed to the returned function are added to the arguments originally passed
+to apply.
+
+__Arguments__
+
+* `function` - The function you want to eventually apply all arguments to.
+* `arguments...` - Any number of arguments to automatically apply when the
+  continuation is called.
+
+__Example__
+
+```js
+// using apply
+
+async.parallel([
+    async.apply(fs.writeFile, 'testfile1', 'test1'),
+    async.apply(fs.writeFile, 'testfile2', 'test2'),
+]);
+
+
+// the same process without using apply
+
+async.parallel([
+    function(callback){
+        fs.writeFile('testfile1', 'test1', callback);
+    },
+    function(callback){
+        fs.writeFile('testfile2', 'test2', callback);
+    }
+]);
+```
+
+It's possible to pass any number of additional arguments when calling the
+continuation:
+
+```js
+node> var fn = async.apply(sys.puts, 'one');
+node> fn('two', 'three');
+one
+two
+three
+```
+
+---------------------------------------
+
+<a name="nextTick" />
+### nextTick(callback), setImmediate(callback)
+
+Calls `callback` on a later loop around the event loop. In Node.js this just
+calls `process.nextTick`; in the browser it falls back to `setImmediate(callback)`
+if available, otherwise `setTimeout(callback, 0)`, which means other higher priority
+events may precede the execution of `callback`.
+
+This is used internally for browser-compatibility purposes.
+
+__Arguments__
+
+* `callback` - The function to call on a later loop around the event loop.
+
+__Example__
+
+```js
+var call_order = [];
+async.nextTick(function(){
+    call_order.push('two');
+    // call_order now equals ['one','two']
+});
+call_order.push('one')
+```
+
+<a name="times" />
+### times(n, callback)
+
+Calls the `callback` function `n` times, and accumulates results in the same manner
+you would use with [`map`](#map).
+
+__Arguments__
+
+* `n` - The number of times to run the function.
+* `callback` - The function to call `n` times.
+
+__Example__
+
+```js
+// Pretend this is some complicated async factory
+var createUser = function(id, callback) {
+  callback(null, {
+    id: 'user' + id
+  })
+}
+// generate 5 users
+async.times(5, function(n, next){
+    createUser(n, function(err, user) {
+      next(err, user)
+    })
+}, function(err, users) {
+  // we should now have 5 users
+});
+```
+
+<a name="timesSeries" />
+### timesSeries(n, callback)
+
+The same as [`times`](#times), only the iterator is applied to each item in `arr` in
+series. The next `iterator` is only called once the current one has completed. 
+The results array will be in the same order as the original.
+
+
+## Utils
+
+<a name="memoize" />
+### memoize(fn, [hasher])
+
+Caches the results of an `async` function. When creating a hash to store function
+results against, the callback is omitted from the hash and an optional hash
+function can be used.
+
+The cache of results is exposed as the `memo` property of the function returned
+by `memoize`.
+
+__Arguments__
+
+* `fn` - The function to proxy and cache results from.
+* `hasher` - Tn optional function for generating a custom hash for storing
+  results. It has all the arguments applied to it apart from the callback, and
+  must be synchronous.
+
+__Example__
+
+```js
+var slow_fn = function (name, callback) {
+    // do something
+    callback(null, result);
+};
+var fn = async.memoize(slow_fn);
+
+// fn can now be used as if it were slow_fn
+fn('some name', function () {
+    // callback
+});
+```
+
+<a name="unmemoize" />
+### unmemoize(fn)
+
+Undoes a [`memoize`](#memoize)d function, reverting it to the original, unmemoized
+form. Handy for testing.
+
+__Arguments__
+
+* `fn` - the memoized function
+
+<a name="log" />
+### log(function, arguments)
+
+Logs the result of an `async` function to the `console`. Only works in Node.js or
+in browsers that support `console.log` and `console.error` (such as FF and Chrome).
+If multiple arguments are returned from the async function, `console.log` is
+called on each argument in order.
+
+__Arguments__
+
+* `function` - The function you want to eventually apply all arguments to.
+* `arguments...` - Any number of arguments to apply to the function.
+
+__Example__
+
+```js
+var hello = function(name, callback){
+    setTimeout(function(){
+        callback(null, 'hello ' + name);
+    }, 1000);
+};
+```
+```js
+node> async.log(hello, 'world');
+'hello world'
+```
+
+---------------------------------------
+
+<a name="dir" />
+### dir(function, arguments)
+
+Logs the result of an `async` function to the `console` using `console.dir` to
+display the properties of the resulting object. Only works in Node.js or
+in browsers that support `console.dir` and `console.error` (such as FF and Chrome).
+If multiple arguments are returned from the async function, `console.dir` is
+called on each argument in order.
+
+__Arguments__
+
+* `function` - The function you want to eventually apply all arguments to.
+* `arguments...` - Any number of arguments to apply to the function.
+
+__Example__
+
+```js
+var hello = function(name, callback){
+    setTimeout(function(){
+        callback(null, {hello: name});
+    }, 1000);
+};
+```
+```js
+node> async.dir(hello, 'world');
+{hello: 'world'}
+```
+
+---------------------------------------
+
+<a name="noConflict" />
+### noConflict()
+
+Changes the value of `async` back to its original value, returning a reference to the
+`async` object.

--- a/test/fixtures/readmes/benchmark.md
+++ b/test/fixtures/readmes/benchmark.md
@@ -1,0 +1,131 @@
+# Benchmark.js <sup>v1.0.0</sup>
+
+A [robust](http://calendar.perfplanet.com/2010/bulletproof-javascript-benchmarks/ "Bulletproof JavaScript benchmarks") benchmarking library that works on nearly all JavaScript platforms<sup><a name="fnref1" href="#fn1">1</a></sup>, supports high-resolution timers, and returns statistically significant results. As seen on [jsPerf](http://jsperf.com/).
+
+## BestieJS
+
+Benchmark.js is part of the BestieJS *"Best in Class"* module collection. This means we promote solid browser/environment support, ES5 precedents, unit testing, and plenty of documentation.
+
+## Documentation
+
+The documentation for Benchmark.js can be viewed here: <http://benchmarkjs.com/docs>
+
+For a list of upcoming features, check out our [roadmap](https://github.com/bestiejs/benchmark.js/wiki/Roadmap).
+
+## Support
+
+Benchmark.js has been tested in at least Adobe AIR 3.1, Chrome 5-21, Firefox 1.5-13, IE 6-9, Opera 9.25-12.01, Safari 3-6, Node.js 0.8.6, Narwhal 0.3.2, RingoJS 0.8, and Rhino 1.7RC5.
+
+## Installation and usage
+
+In a browser or Adobe AIR:
+
+~~~ html
+<script src="benchmark.js"></script>
+~~~
+
+Optionally, expose Java’s nanosecond timer by adding the `nano` applet to the `<body>`:
+
+~~~ html
+<applet code="nano" archive="nano.jar"></applet>
+~~~
+
+Or enable Chrome’s microsecond timer by using the [command line switch](http://peter.sh/experiments/chromium-command-line-switches/#enable-benchmarking):
+
+    --enable-benchmarking
+
+Via [npm](http://npmjs.org/):
+
+~~~ bash
+npm install benchmark
+~~~
+
+In [Node.js](http://nodejs.org/) and [RingoJS v0.8.0+](http://ringojs.org/):
+
+~~~ js
+var Benchmark = require('benchmark');
+~~~
+
+Optionally, use the [microtime module](https://github.com/wadey/node-microtime) by Wade Simmons:
+
+~~~ bash
+npm install microtime
+~~~
+
+In [RingoJS v0.7.0-](http://ringojs.org/):
+
+~~~ js
+var Benchmark = require('benchmark').Benchmark;
+~~~
+
+In [Rhino](http://www.mozilla.org/rhino/):
+
+~~~ js
+load('benchmark.js');
+~~~
+
+In an AMD loader like [RequireJS](http://requirejs.org/):
+
+~~~ js
+require({
+  'paths': {
+    'benchmark': 'path/to/benchmark'
+  }
+},
+['benchmark'], function(Benchmark) {
+  console.log(Benchmark.version);
+});
+
+// or with platform.js
+// https://github.com/bestiejs/platform.js
+require({
+  'paths': {
+    'benchmark': 'path/to/benchmark',
+    'platform': 'path/to/platform'
+  }
+},
+['benchmark', 'platform'], function(Benchmark, platform) {
+  Benchmark.platform = platform;
+  console.log(Benchmark.platform.name);
+});
+~~~
+
+Usage example:
+
+~~~ js
+var suite = new Benchmark.Suite;
+
+// add tests
+suite.add('RegExp#test', function() {
+  /o/.test('Hello World!');
+})
+.add('String#indexOf', function() {
+  'Hello World!'.indexOf('o') > -1;
+})
+// add listeners
+.on('cycle', function(event) {
+  console.log(String(event.target));
+})
+.on('complete', function() {
+  console.log('Fastest is ' + this.filter('fastest').pluck('name'));
+})
+// run async
+.run({ 'async': true });
+
+// logs:
+// > RegExp#test x 4,161,532 +-0.99% (59 cycles)
+// > String#indexOf x 6,139,623 +-1.00% (131 cycles)
+// > Fastest is String#indexOf
+~~~
+
+## Authors
+
+* [Mathias Bynens](http://mathiasbynens.be/)
+  [![twitter/mathias](http://gravatar.com/avatar/24e08a9ea84deb17ae121074d0f17125?s=70)](https://twitter.com/mathias "Follow @mathias on Twitter")
+* [John-David Dalton](http://allyoucanleet.com/)
+  [![twitter/jdalton](http://gravatar.com/avatar/299a3d891ff1920b69c364d061007043?s=70)](https://twitter.com/jdalton "Follow @jdalton on Twitter")
+
+## Contributors
+
+* [Kit Cambridge](http://kitcambridge.github.com/)
+  [![twitter/kitcambridge](http://gravatar.com/avatar/6662a1d02f351b5ef2f8b4d815804661?s=70)](https://twitter.com/kitcambridge "Follow @kitcambridge on Twitter")

--- a/test/fixtures/readmes/cicada.md
+++ b/test/fixtures/readmes/cicada.md
@@ -1,0 +1,144 @@
+# cicada
+
+a teeny git-based continuous integration server
+
+[![build status](https://secure.travis-ci.org/substack/cicada.png)](http://travis-ci.org/substack/cicada)
+
+# example
+
+Just hack up a cicada server:
+
+``` js
+var http = require('http');
+var cicada = require('cicada');
+
+var ci = cicada('/tmp/blarg');
+ci.on('commit', function (commit) {
+    commit.run('test').on('exit', function (code) {
+        var status = code === 0 ? 'PASSED' : 'FAILED';
+        console.log(commit.hash + ' ' + status);
+    });
+});
+
+var server = http.createServer(ci.handle);
+server.listen(5255);
+```
+
+run it
+
+```
+$ node example/ci.js 
+```
+
+push some code to it:
+
+```
+$ git push http://localhost:5255/choose.git 
+To http://localhost:5255/choose.git
+   c79cef8..3537c0f  master -> master
+```
+
+and watch the results whiz by!
+
+```
+b7c19c9fd2c34176bd6eef436a69ab7a470ff98d PASSED
+c79cef8c54a9abc2b2d6ecd179d41463767be526 FAILED
+3537c0f83606788bdfb065242a6851b20504fe3e PASSED
+```
+
+# methods
+
+``` js
+var cicada = require('cicada')
+```
+
+## var ci = cicada(opts, cb)
+
+Create a new ci server using `opts.repodir` for storing git blobs and
+`opts.workdir` for checking out code.
+
+If `opts.repodir` is a function, check out repositories to the directory
+specified by the return value of `opts.repodir(repo)` where `repo` is the repo
+name as a string.
+
+If `opts.workdir` is a function, check out repositories to the directory
+specified by the return value of `opts.workdir(commit)` where `commit` is a
+commit object described below.
+
+If `opts` is a string, use `opts + '/repo'` and `opts + '/work'`.
+
+If `opts.basedir` is a string, use `opts.basedir + '/repo'` and `opts.basedir + '/work'`.
+
+If `opts.bare` is `true` the repo will not be checked out into the `workdir` during a push. If not specified `opts.bare` defaults to `false`.
+
+If `cb` is provided, it acts as a listener for the `'commit'` event.
+
+## ci.handle(req, res)
+
+Handle requests from an http server. This is necessary to make git work over
+http.
+
+## ci.checkout(repo, commit, branch, cb)
+
+Manually check out a commit into the workdir.
+
+The errback `cb(err, commit)` fires with an error or a commit object.
+
+# events
+
+## ci.on('push', function (push) {})
+
+Emitted when somebody pushes to the server.
+
+`push` comes from the [`pushover`](https://github.com/substack/pushover#reposonpush-function-push---) module.
+
+If you implement a `on('push')` handler you must call `push.accept()` inside of it for the push to complete, otherwise the git client will hang on the other end.
+
+## ci.on('commit', function (commit) {})
+
+After a push occurs, the commit will be checked out into the workdir.
+Once the commit is all checked out, this event fires with a commit handle
+described below.
+
+## ci.on('error', function (err) {}
+
+Emitted when errors occur.
+
+# commit object
+
+Commit objects are emitted by the `'commit'` event or they may be created
+manually with the `ci.checkout()` function.
+
+## commit.run(scriptName, opts)
+
+Run a command from the package.json script hash with `npm run-script`.
+
+Returns the process object.
+
+## commit.spawn(command, args, opts)
+
+Spawn an ordinary shell command in the `commit.dir`.
+
+Returns the process object.
+
+## commit properties
+
+commit objects have these properties:
+
+* commit.hash - the full git hash string for this commit
+* commit.id - a combination of the hash and the date in microseconds
+* commit.dir - the working directory the commit is checked out into
+* commit.repo - the repository this commit came from
+* commit.branch - the branch this commit came from
+
+# install
+
+With [npm](http://npmjs.org) do:
+
+```
+npm install cicada
+```
+
+# license
+
+MIT

--- a/test/fixtures/readmes/express.md
+++ b/test/fixtures/readmes/express.md
@@ -1,0 +1,138 @@
+[![Express Logo](https://i.cloudup.com/zfY6lL7eFa-3000x3000.png)](http://expressjs.com/)
+
+  Fast, unopinionated, minimalist web framework for [node](http://nodejs.org).
+
+  [![NPM Version][npm-image]][npm-url]
+  [![NPM Downloads][downloads-image]][downloads-url]
+  [![Linux Build][travis-image]][travis-url]
+  [![Windows Build][appveyor-image]][appveyor-url]
+  [![Test Coverage][coveralls-image]][coveralls-url]
+
+```js
+var express = require('express')
+var app = express()
+
+app.get('/', function (req, res) {
+  res.send('Hello World')
+})
+
+app.listen(3000)
+```
+
+## Installation
+
+```bash
+$ npm install express
+```
+
+## Features
+
+  * Robust routing
+  * Focus on high performance
+  * Super-high test coverage
+  * HTTP helpers (redirection, caching, etc)
+  * View system supporting 14+ template engines
+  * Content negotiation
+  * Executable for generating applications quickly
+
+## Docs & Community
+
+  * [Website and Documentation](http://expressjs.com/) - [[website repo](https://github.com/strongloop/expressjs.com)]
+  * [#express](https://webchat.freenode.net/?channels=express) on freenode IRC
+  * [Github Organization](https://github.com/expressjs) for Official Middleware & Modules
+  * Visit the [Wiki](https://github.com/strongloop/express/wiki)
+  * [Google Group](https://groups.google.com/group/express-js) for discussion
+  * [Русскоязычная документация](http://jsman.ru/express/)
+  * [한국어 문서](http://expressjs.kr) - [[website repo](https://github.com/Hanul/expressjs.kr)]
+
+**PROTIP** Be sure to read [Migrating from 3.x to 4.x](https://github.com/strongloop/express/wiki/Migrating-from-3.x-to-4.x) as well as [New features in 4.x](https://github.com/strongloop/express/wiki/New-features-in-4.x).
+
+## Quick Start
+
+  The quickest way to get started with express is to utilize the executable [`express(1)`](https://github.com/expressjs/generator) to generate an application as shown below:
+
+  Install the executable. The executable's major version will match Express's:
+
+```bash
+$ npm install -g express-generator@4
+```
+
+  Create the app:
+
+```bash
+$ express /tmp/foo && cd /tmp/foo
+```
+
+  Install dependencies:
+
+```bash
+$ npm install
+```
+
+  Start the server:
+
+```bash
+$ npm start
+```
+
+## Philosophy
+
+  The Express philosophy is to provide small, robust tooling for HTTP servers, making
+  it a great solution for single page applications, web sites, hybrids, or public
+  HTTP APIs.
+
+  Express does not force you to use any specific ORM or template engine. With support for over
+  14 template engines via [Consolidate.js](https://github.com/tj/consolidate.js),
+  you can quickly craft your perfect framework.
+
+## Examples
+
+  To view the examples, clone the Express repo and install the dependencies:
+
+```bash
+$ git clone git://github.com/strongloop/express.git --depth 1
+$ cd express
+$ npm install
+```
+
+  Then run whichever example you want:
+
+```bash
+$ node examples/content-negotiation
+```
+
+## Tests
+
+  To run the test suite, first install the dependencies, then run `npm test`:
+
+```bash
+$ npm install
+$ npm test
+```
+
+## People
+
+The original author of Express is [TJ Holowaychuk](https://github.com/tj) [![TJ's Gratipay][gratipay-image-visionmedia]][gratipay-url-visionmedia]
+
+The current lead maintainer is [Douglas Christopher Wilson](https://github.com/dougwilson) [![Doug's Gratipay][gratipay-image-dougwilson]][gratipay-url-dougwilson]
+
+[List of all contributors](https://github.com/strongloop/express/graphs/contributors)
+
+## License
+
+  [MIT](LICENSE)
+
+[npm-image]: https://img.shields.io/npm/v/express.svg
+[npm-url]: https://npmjs.org/package/express
+[downloads-image]: https://img.shields.io/npm/dm/express.svg
+[downloads-url]: https://npmjs.org/package/express
+[travis-image]: https://img.shields.io/travis/strongloop/express/master.svg?label=linux
+[travis-url]: https://travis-ci.org/strongloop/express
+[appveyor-image]: https://img.shields.io/appveyor/ci/dougwilson/express/master.svg?label=windows
+[appveyor-url]: https://ci.appveyor.com/project/dougwilson/express
+[coveralls-image]: https://img.shields.io/coveralls/strongloop/express/master.svg
+[coveralls-url]: https://coveralls.io/r/strongloop/express?branch=master
+[gratipay-image-visionmedia]: https://img.shields.io/gratipay/visionmedia.svg
+[gratipay-url-visionmedia]: https://gratipay.com/visionmedia/
+[gratipay-image-dougwilson]: https://img.shields.io/gratipay/dougwilson.svg
+[gratipay-url-dougwilson]: https://gratipay.com/dougwilson/

--- a/test/fixtures/readmes/grunt-angular-templates.md
+++ b/test/fixtures/readmes/grunt-angular-templates.md
@@ -1,0 +1,420 @@
+# grunt-angular-templates
+
+[![Build Status](https://travis-ci.org/ericclemmons/grunt-angular-templates.svg)](https://travis-ci.org/ericclemmons/grunt-angular-templates)
+[![Dependencies](https://david-dm.org/ericclemmons/grunt-angular-templates.svg)](https://david-dm.org/ericclemmons/grunt-angular-templates)
+[![devDependencies](https://david-dm.org/ericclemmons/grunt-angular-templates/dev-status.svg)](https://david-dm.org/ericclemmons/grunt-angular-templates#info=devDependencies&view=table)
+
+> Speed up your AngularJS app by automatically minifying, combining,
+> and automatically caching your HTML templates with `$templateCache`.
+
+Here's an example of the output created by this task from multiple `.html` files:
+
+```js
+angular.module('app').run(["$templateCache", function($templateCache) {
+  $templateCache.put("home.html",
+    // contents for home.html ...
+  );
+  ...
+  $templateCache.put("src/app/templates/button.html",
+    // contents for button.html
+  );
+}]);
+```
+
+Then, when you use `ng-include` or `templateUrl` with `$routeProvider`,
+the template is already loaded without an extra AJAX request!
+
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Options](#options)
+- [Usage](#usage)
+- [Examples](#examples)
+- [Changelog](#changelog)
+- [License](#license)
+
+
+## Installation
+
+*This plugin requires [Grunt][1] `~0.4.0`*
+
+*Usemin integration requires [grunt-usemin][5] `~2.0.0`*
+
+Install the plugin:
+
+    $ npm install grunt-angular-templates --save-dev
+
+Enable the plugin within your `Gruntfile`:
+
+```js
+grunt.loadNpmTasks('grunt-angular-templates');
+```
+
+
+## Options
+
+### angular
+
+> Global namespace for Angular.
+
+If you use `angular.noConflict()`, then set this value to whatever you
+re-assign angular to.  Otherwise, it defaults to `angular`.
+
+### bootstrap
+
+> Callback to modify the bootstraper that registers the templates with `$templateCache`.
+
+By default, the bootstrap script wraps `function($templateCache) { ... }` with:
+
+```js
+angular.module('app').run(['$templateCache', ... ]);
+```
+
+If you want to create your own wrapper so you register the templates as an
+AMD or CommonJS module, set the `bootstrap` option to something like:
+
+```js
+bootstrap: function(module, script) {
+  return 'module.exports[module] = ' + script + ';';
+}
+```
+
+### concat
+
+> Name of `concat` target to append the compiled template path to.
+
+This is especially handy if you combine your scripts using
+[grunt-contrib-concat][4] or [grunt-usemin][5].
+
+### htmlmin
+
+> Object containing [htmlmin options][2] that will *significantly* reduce
+the filesize of the compiled templates.
+
+Without this, the HTML (whitespace and all) will be faithfully compiled
+down into the final `.js` file.  Minifying that file will only cut down
+on the *Javascript* code, not the *HTML* within the strings.
+
+I recommend using the following settings for production:
+
+```js
+htmlmin: {
+  collapseBooleanAttributes:      true,
+  collapseWhitespace:             true,
+  removeAttributeQuotes:          true,
+  removeComments:                 true, // Only if you don't use comment directives!
+  removeEmptyAttributes:          true,
+  removeRedundantAttributes:      true,
+  removeScriptTypeAttributes:     true,
+  removeStyleLinkTypeAttributes:  true
+}
+```
+If you are using SVG, please make sure you set ```keepClosingSlash:true```
+
+### module
+
+> `String` of the `angular.module` to register templates with.
+
+If not specified, it will automatically be the name of the `ngtemplates`
+subtask (e.g. `app`, based on the examples below).
+
+### prefix
+
+> `String` to prefix template URLs with.
+Defaults to `''`
+
+If you need to use absolute urls:
+
+```js
+ngtemplates: {
+  app: {
+    options: {
+      prefix: '/'
+    }
+  }
+}
+```
+
+If you serve static assets from another directory, you specify that as well.
+
+### source
+
+> Callback to modify the template's source code.
+
+If you would like to prepend a comment, strip whitespace, or do
+post-processing on the HTML that `ngtemplates` doesn't otherwise do,
+use this function.
+
+### append
+
+> Boolean to indicate the templates should be appended to dest instead of replacing it.
+Normally grunt-angular-templates creates a new file at `dest`.
+This option makes it append the compiled templates to the `dest` file rather than replace its contents.
+This is just a useful alternative to creating a temporary `dest` file and concatting it to your application.
+
+
+### standalone
+
+> Boolean indicated if the templates are part of an existing module or a standalone.
+Defaults to `false`.
+
+- If the value is `false`, the module will look like `angular.module('app')`, meaning `app` module is retrieved.
+- If the value is `true`, the module will look like `angular.module('app', [])`, meaning `app` module is created.
+
+### url
+
+> Callback to modify the template's `$templateCache` URL.
+
+Normally, this isn't needed as specifying your files with `cwd`
+ensures that URLs load via both AJAX and `$templateCache`.
+
+### usemin
+
+> Path to `<!-- build:js [path/to/output.js] -->` usemin target
+
+This should be the output path of the compiled JS indicated in your HTML,
+such as `path/to/output.js` shown here.
+
+## Usage
+
+
+### Compiling HTML Templates
+
+After configuring your `ngtemplates` task, you can either run the
+task directly:
+
+    $ grunt ngtemplates
+
+Or, bake it into an existing task:
+
+```js
+grunt.registerTask('default', [ 'jshint', 'ngtemplates', 'concat' ]);
+```
+
+### Including Compiled Templates
+
+Finally, you have to load the compiled templates' `.js` file into your
+application.
+
+
+#### Using HTML
+
+```html
+<script src="templates.js"></script>
+```
+
+
+#### Using Grunt's `concat` task:
+
+This is my personal preference, since you don't have to worry about
+what the destination file is actually called.
+
+```js
+concat:   {
+  app:    {
+    src:  [ '**.js', '<%= ngtemplates.app.dest %>' ],
+    dest: [ 'app.js' ]
+  }
+}
+```
+
+#### Using [grunt-usemin][5]
+
+Using the following HTML as an example:
+
+```html
+<!-- build:js dist/vendors.js -->
+<script src="bower_components/angular/angular.js"></script>
+<script src="bower_components/angular-resource/angular-resource.js"></script>
+<!-- endbuild -->
+```
+
+**Do not use the `concat` option**, even though grunt-usemin generates a `concat.generated`
+object behind the scenes.  Instead, use the `usemin` option to indicate the anticipated
+output filepath from grunt-usemin.
+
+```js
+ngtemplates:  {
+  app:        {
+    src:      '**.html',
+    dest:     'template.js',
+    options:  {
+      usemin: 'dist/vendors.js' // <~~ This came from the <!-- build:js --> block
+    }
+  }
+}
+```
+
+**Note**: Earlier versions of grunt-usemin (*correctly, in my opinion*) would have generated
+a `concat['dist/vendors.js']` object for each build section in the HTML.  Now,
+because there's a single `concat.generated` object with **all** JS/CSS files within it,
+I'm back-tracking the proper `concat` target for you.
+
+## Examples
+
+
+### Register HTML Templates in `app` Module
+
+```js
+ngtemplates:  {
+  app:        {
+    src:      '**.html',
+    dest:     'templates.js'
+  }
+}
+```
+
+
+### Register Relative Template URLs
+
+Normally, your app, templates, & server are in separate folders, which means
+that the template URL is **different** from the file path.
+
+```js
+ngtemplates:  {
+  app:        {
+    cwd:      'src/app',
+    src:      'templates/**.html',
+    dest:     'build/app.templates.js'
+  }
+}
+```
+
+This will store the template URL as `templates/home.html` instead of
+`src/app/templates/home.html`, which would cause a 404.
+
+
+### Minify Template HTML
+
+Simply pass the [same options][2] as the `htmlmin` task:
+
+```js
+ngtemplates:    {
+  app:          {
+    src:        '**.html',
+    dest:       'templates.js',
+    options:    {
+      htmlmin:  { collapseWhitespace: true, collapseBooleanAttributes: true }
+    }
+  }
+}
+```
+
+Or, if you already have an existing `htmlmin` task, you can reference it:
+
+```js
+ngtemplates:    {
+  app:          {
+    src:        '**.html',
+    dest:       'templates.js',
+    options:    {
+      htmlmin:  '<%= htmlmin.app %>'
+    }
+  }
+}
+```
+
+
+### Customize Template URL
+
+Suppose you only use `ngtemplates` when on production, but locally you serve
+templates via Node, sans the `.html` extension.
+
+You can specify a `url` callback to further customize the registered URL:
+
+```js
+ngtemplates:  {
+  app:        {
+    src:      '**.html',
+    dest:     'templates.js',
+    options:  {
+      url:    function(url) { return url.replace('.html', ''); }
+    }
+  }
+}
+```
+
+
+### Customize Output
+
+Some people like [AMD & RequireJS][3] and would like wrap the output
+in AMD or something else (don't ask me why!):
+
+```js
+ngtemplates:      {
+  app:            {
+    src:          '**.html',
+    dest:         'templates.js',
+    options:      {
+      bootstrap:  function(module, script) {
+        return 'define(' + module + ', [], function() { return { init: ' + script + ' }; });';
+      }
+    }
+  }
+}
+```
+
+You will be able to custom everything surrounding `$templateCache.put(...)`.
+
+
+## Changelog
+
+- v0.5.9 - Fixes over-matching on `cwd` when `expand:true`
+- v0.5.8 - Fixes `cwd` being part of the $templateCache string when `expand:true` ([#134](https://github.com/ericclemmons/grunt-angular-templates/pull/134)), Added verbose logging for minify ([#136](https://github.com/ericclemmons/grunt-angular-templates/pull/136))
+- v0.5.7 – Improve error messages ([#100](https://github.com/ericclemmons/grunt-angular-templates/pull/100))
+- v0.5.6 – Updated `html-minifier` to correct whitespace issues. ([96](https://github.com/ericclemmons/grunt-angular-templates/pull/96))
+- v0.5.5 – Add `append` option to concat, not overwrite the `dest`. ([#89](https://github.com/ericclemmons/grunt-angular-templates/pull/89))
+- v0.5.4 – Specifying an invalid `usemin` option still creates file ([#84](https://github.com/ericclemmons/grunt-angular-templates/pull/84))
+- v0.5.3 – Fix bug with Underscore templates ([#79](https://github.com/ericclemmons/grunt-angular-templates/pull/79))
+- v0.5.2 – Fix `usemin` matching issue on Windows ([#80](https://github.com/ericclemmons/grunt-angular-templates/pull/80))
+- v0.5.1 – Add `usemin` option form v0.4.10
+- v0.5.0 – Works with `grunt-usemin` ([#44](https://github.com/ericclemmons/grunt-angular-templates/issues/44))
+- v0.4.10 – Add `usemin` option
+- v0.4.9 – Improve `prefix` and support for URLs ([#57](https://github.com/ericclemmons/grunt-angular-templates/pull/57))
+- v0.4.8 – Compiled assets are JSHint-able ([#58](https://github.com/ericclemmons/grunt-angular-templates/pull/58))
+- v0.4.7 – Fix bug for when htmlmin is not an Object ([#56](https://github.com/ericclemmons/grunt-angular-templates/issues/56))
+- v0.4.6 – Add `prefix` option for easier URL prefixes ([#53](https://github.com/ericclemmons/grunt-angular-templates/pull/53))
+- v0.4.5 – Attempt to better normalize templates based on current OS ([#52](https://github.com/ericclemmons/grunt-angular-templates/pull/52))
+- v0.4.4 – Fixed regression caused by `htmlmin` ([#54](https://github.com/ericclemmons/grunt-angular-templates/pull/54))
+- v0.4.3 - `options.concat` targets on Windows convert `/` to `\\`. [#48](https://github.com/ericclemmons/grunt-angular-templates/issues/48)
+- v0.4.2 - Fix for using `grunt-env` to change environments. Thanks to @FredrikAppelros ([#20](https://github.com/ericclemmons/grunt-express-server/pull/20))
+- v0.4.1 – Fix bug with empty files.
+- v0.4.0 – Complete rewrite.
+- v0.3.12 – Whoops, forgot to make `htmlmin` a regular dependency. Thanks  @rubenv ([#37](https://github.com/ericclemmons/grunt-angular-templates/pull/37))
+- v0.3.11 – Add `htmlmin` option that supports both an `{ ... }` and `<%= htmlmin.options %>` for existing tasks.
+- v0.3.10 – Fix *unknown concat target* bug on windows, thanks to @trask ([#31](https://github.com/ericclemmons/grunt-angular-templates/pull/31))
+- v0.3.9 – Allow the creation of a new module via `module.define`, thanks to @sidwood ([#28](https://github.com/ericclemmons/grunt-angular-templates/pull/28))
+- v0.3.8 – Fix error that occurs when adding 0-length files, thanks to @robertklep ([#27](https://github.com/ericclemmons/grunt-angular-templates/pull/27))
+- v0.3.7 – Add `noConflict` option to work with [angular.noConflict](https://github.com/angular/angular.js/pull/1535), thanks to @mbrevoort ([#26](https://github.com/ericclemmons/grunt-angular-templates/pull/26))
+- v0.3.6 – Fix issue with dading to `concat` task when it's an array, thanks to @codefather ([#23](https://github.com/ericclemmons/grunt-angular-templates/pull/23))
+- v0.3.5 – Preserver line endings in templates, thanks to @groner ([#21](https://github.com/ericclemmons/grunt-angular-templates/pull/21))
+- v0.3.4 – Attempt to fix a bug with `Path`, thanks to @cgross ([#19](https://github.com/ericclemmons/grunt-angular-templates/issues/19))
+- v0.3.3 – Add `concat` option for automatically adding compiled template file to existing `concat` (or `usemin`-created) task, thanks to @cgross ([#17](https://github.com/ericclemmons/grunt-angular-templates/pull/17))
+- v0.3.2 – Add `module` option for setting which module the templates will be added to, thanks to @sidwood ([#20](https://github.com/ericclemmons/grunt-angular-templates/pull/20))
+- v0.3.1 – Add `prepend` option for modifying final `$templateCache` IDs, thanks to @mbarchein. ([#16](https://github.com/ericclemmons/grunt-angular-templates/pull/16))
+- v0.3.0 – **BC break** - Templates are added to an existing module (e.g. `myapp`) rather than being their own `myapp.templates` module to be manually included, thanks to @geddesign. ([#10](https://github.com/ericclemmons/grunt-angular-templates/issues/10))
+- v0.2.2 – Escape backslashes, thanks to @dallonf. ([#9](https://github.com/ericclemmons/grunt-angular-templates/pull/9))
+- v0.2.1 – Remove `./bin/grunt-angular-templates`.  No need for it!
+- v0.2.0 – Update to Grunt 0.4, thanks to @jgrund. ([#5](https://github.com/ericclemmons/grunt-angular-templates/issues/5))
+- v0.1.3 – Convert `\\` to `/` in template IDs (for on win32 systems) ([#3](https://github.com/ericclemmons/grunt-angular-templates/issues/3))
+- v0.1.2 – Added NPM keywords
+- v0.1.1 – [Fails to combine multiple templates](https://github.com/ericclemmons/grunt-angular-templates/issues/1). Added directions to README on how to integrate with AngularJS app. Integrated with TravisCI
+- v0.1.0 – Released to [NPM](https://npmjs.org/package/grunt-angular-templates)
+
+
+## License
+
+Copyright (c) 2013 Eric Clemmons
+Licensed under the MIT license.
+
+
+[1]: http://gruntjs.com/
+[2]: https://github.com/gruntjs/grunt-contrib-htmlmin
+[3]: http://requirejs.org/docs/whyamd.html
+[4]: https://github.com/gruntjs/grunt-contrib-concat
+[5]: https://github.com/yeoman/grunt-usemin
+
+
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/ericclemmons/grunt-angular-templates/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+

--- a/test/fixtures/readmes/johnny-five.md
+++ b/test/fixtures/readmes/johnny-five.md
@@ -1,0 +1,506 @@
+![](https://github.com/rwaldron/johnny-five/raw/master/assets/sgier-johnny-five.png)
+
+# Johnny-Five
+### The JavaScript Robotics Programming Framework
+
+<!-- 
+
+    Hello!
+
+    Please don't edit this file!
+
+    If you'd like to make changes to the readme contents, please make them in the tpl/.readme.md file. If you'd like to add an example: 
+
+    1. Add the file in `eg/`
+    2. Add a breadboard image in `docs/breadboards`
+    3. Add an entry to `tpl/programs.json`. 
+    4. Generated the markdown with: `grunt examples`
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+-->
+
+
+_Artwork by [Mike Sgier](http://msgierillustration.com)_
+
+[![Build Status](https://travis-ci.org/rwaldron/johnny-five.svg?branch=master)](https://travis-ci.org/rwaldron/johnny-five) 
+[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/rwaldron/johnny-five?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+
+
+**Johnny-Five is an Open Source, Firmata Protocol based, IoT and Robotics programming framework, developed at [Bocoup](http://bocoup.com). Johnny-Five programs can be written for Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!**
+
+Johnny-Five has grown from a passion project into a tool for inspiring learning and creativity for people of all ages, backgrounds, and from all across the world. 
+
+Just interested in learning and building awesome things? You might want to start with the official [Johnny-Five website](http://johnny-five.io). The website combines content from this repo, the wiki, tutorials from the Bocoup blog and several third-party websites into a single, easily-discoverable source:
+
+* If you want to find the API documentation, [that’s right here](http://johnny-five.io/api/).
+* Need to figure out what platform to use for a project? We put that stuff [here](http://johnny-five.io/platform-support/).
+* Need inspiration for your next NodeBot? Check out the [examples](http://johnny-five.io/examples/).
+* Want to stay up-to-date with projects in the community? [Check this out](http://johnny-five.io/articles/).
+* Need NodeBots community or Johnny-Five project updates and announcements? [This](http://johnny-five.io/news/) is what you’re looking for.
+
+
+Johnny-Five does not attempt to provide "all the things", but instead focuses on delivering robust, reality tested, highly composable APIs that behave consistently across all supported hardware platforms. Johnny-Five wants to be a baseline control kit for hardware projects, allowing you the freedom to build, grow and experiment with diverse JavaScript libraries of your own choice. Johnny-Five couples comfortably with:
+
+- Popular application libraries such as [Express.js](http://expressjs.com/) and [Socket.io](http://socket.io/).
+- Fellow hardware projects like [ar-drone](https://github.com/felixge/node-ar-drone), [Aerogel](https://github.com/ceejbot/aerogel) and [Spheron](https://github.com/alchemycs/spheron)
+- Bluetooth game controllers like [XBox Controller](https://github.com/andrew/node-xbox-controller) and [DualShock](https://github.com/rdepena/node-dualshock-controller)
+- IoT frameworks, such as [Octoblu](http://www.octoblu.com/)
+
+...And that's only a few of the many explorable possibilities. Check out these exciting projects: [node-pulsesensor](https://www.npmjs.org/package/node-pulsesensor), [footballbot-workshop-ui](https://www.npmjs.org/package/footballbot-workshop-ui), [nodebotui](https://www.npmjs.org/package/nodebotui), [dublin-disco](https://www.npmjs.org/package/dublin-disco), [node-slot-car-bot](https://www.npmjs.org/package/node-slot-car-bot), [servo-calibrator](https://www.npmjs.org/package/servo-calibrator), [node-ardx](https://www.npmjs.org/package/node-ardx), [nodebot-workshop](https://www.npmjs.org/package/nodebot-workshop), [phone-home](https://www.npmjs.org/package/phone-home), [purple-unicorn](https://www.npmjs.org/package/purple-unicorn), [webduino](https://www.npmjs.org/package/webduino), [leapduino](https://www.npmjs.org/package/leapduino), [lasercat-workshop](https://www.npmjs.org/package/lasercat-workshop), [simplesense](https://www.npmjs.org/package/simplesense), [five-redbot](https://www.npmjs.org/package/five-redbot), [robotnik](https://www.npmjs.org/package/robotnik), [the-blender](https://www.npmjs.org/package/the-blender)
+
+
+**Why JavaScript?**
+[NodeBots: The Rise of JavaScript Robotics](http://www.voodootikigod.com/nodebots-the-rise-of-js-robotics)
+
+## Hello Johnny
+
+The ubiquitous "Hello World" program of the microcontroller and SoC world is "blink an LED". The following code demonstrates how this is done using the Johnny-Five framework.
+
+```javascript
+var five = require("johnny-five");
+var board = new five.Board();
+
+board.on("ready", function() {
+  // Create an Led on pin 13
+  var led = new five.Led(13);
+  // Blink every half second
+  led.blink(500); 
+});
+```
+
+<img src="https://github.com/rwaldron/johnny-five/raw/master/assets/led-blink.gif">
+
+> Note: Node will crash if you try to run johnny-five in the node REPL, but board instances will create their own contextual REPL. Put your script in a file.
+
+
+## Supported Hardware
+
+Johnny-Five has been tested on a variety of Arduino-compatible [Boards](https://github.com/rwaldron/johnny-five/wiki/Board).
+
+For non-Arduino based projects, a number of platform-specific [IO Plugins](https://github.com/rwaldron/johnny-five/wiki/IO-Plugins) are available. IO Plugins allow Johnny-Five code to communicate with any non-Arduino based hardware in whatever language that platforms speaks!
+
+## Documentation
+
+Documentation for the Johnny-Five API can be found [here](http://johnny-five.io/api/) and [example programs here](http://johnny-five.io/examples/).
+
+## Guidance
+
+Need help? Ask a question on the [NodeBots Community Forum](http://forums.nodebots.io). If you just have a quick question or are interested in ongoing design discussions, join us in the [Johnny-Five Gitter Chat](https://gitter.im/rwaldron/johnny-five).
+
+For step-by-step examples, including an electronics primer, check out [Arduino Experimenter's Guide for NodeJS](http://node-ardx.org/) by [@AnnaGerber](https://twitter.com/AnnaGerber)
+
+Here is a list of [prerequisites](https://github.com/rwaldron/johnny-five/wiki/Prerequites) for Linux, OSX or Windows.
+
+Check out the [bluetooth guide](https://github.com/rwaldron/johnny-five/wiki/JY-MCU-Bluetooth-Serial-Port-Module-Notes) if you want to remotely control your robot.
+
+## Setup and Assemble Arduino
+
+- Recommended Starting Kit: [Sparkfun Inventor's Kit](https://www.sparkfun.com/products/12001)
+- Download [Arduino IDE](http://arduino.cc/en/main/software)
+- Plug in your Arduino or Arduino compatible microcontroller via USB
+- Open the Arduino IDE, select: File > Examples > Firmata > StandardFirmata
+- Click the "Upload" button.
+
+If the upload was successful, the board is now prepared and you can close the Arduino IDE.
+
+For non-Arduino projects, each IO Plugin's repo will provide its own platform specific setup instructions.
+
+
+## Hey you, here's Johnny!
+
+#### Source Code:
+
+``` bash
+git clone git://github.com/rwaldron/johnny-five.git && cd johnny-five
+
+npm install
+```
+
+#### npm package:
+
+Install the module with:
+
+```bash
+npm install johnny-five
+```
+
+
+## Example Programs
+
+To get you up and running quickly, we provide a variety of examples for using each Johnny-Five component. One thing we’re especially excited about is the extensive collection of [Fritzing](http://fritzing.org/home/) diagrams you’ll find throughout the site. A huge part of doing any Johnny-Five project is handling the actual hardware, and we’ve included these as part of the documentation because we realised that instructions on how to write code to control a servo are insufficient without instructions on how to connect a servo!
+
+To interactively navigate the examples, visit the [Johnny-Five examples](http://johnny-five.io/examples/) page on the official website. If you want to link directly to the examples in this repo, you can use one of the following links.
+
+<!--extract-start:examples-->
+
+### Board
+- [Basic Board initialization](https://github.com/rwaldron/johnny-five/blob/master/docs/board.md)
+- [Board - Specify port](https://github.com/rwaldron/johnny-five/blob/master/docs/board-with-port.md)
+- [Board - Multiple in one program](https://github.com/rwaldron/johnny-five/blob/master/docs/board-multi.md)
+- [REPL](https://github.com/rwaldron/johnny-five/blob/master/docs/repl.md)
+- [Pin](https://github.com/rwaldron/johnny-five/blob/master/docs/pin.md)
+
+### Expander
+- [Expander - MCP23017](https://github.com/rwaldron/johnny-five/blob/master/docs/expander-MCP23017.md)
+- [Expander - MCP23008](https://github.com/rwaldron/johnny-five/blob/master/docs/expander-MCP23008.md)
+- [Expander - PCF8574](https://github.com/rwaldron/johnny-five/blob/master/docs/expander-PCF8574.md)
+- [Expander - PCF8575](https://github.com/rwaldron/johnny-five/blob/master/docs/expander-PCF8575.md)
+- [Expander - PCA9685](https://github.com/rwaldron/johnny-five/blob/master/docs/expander-PCA9685.md)
+- [Expander - PCF8591](https://github.com/rwaldron/johnny-five/blob/master/docs/expander-PCF8591.md)
+
+### LED
+- [LED](https://github.com/rwaldron/johnny-five/blob/master/docs/led.md)
+- [LED - PCA9685](https://github.com/rwaldron/johnny-five/blob/master/docs/led-PCA9685.md)
+- [LED - Blink](https://github.com/rwaldron/johnny-five/blob/master/docs/led-blink.md)
+- [LED - Pulse](https://github.com/rwaldron/johnny-five/blob/master/docs/led-pulse.md)
+- [LED - Pulse with animation](https://github.com/rwaldron/johnny-five/blob/master/docs/led-pulse-animation.md)
+- [LED - Fade](https://github.com/rwaldron/johnny-five/blob/master/docs/led-fade.md)
+- [LED - Fade callback](https://github.com/rwaldron/johnny-five/blob/master/docs/led-fade-callback.md)
+- [LED - Fade with animation](https://github.com/rwaldron/johnny-five/blob/master/docs/led-fade-animation.md)
+- [LED - Demo sequence](https://github.com/rwaldron/johnny-five/blob/master/docs/led-demo-sequence.md)
+- [LED - Slider](https://github.com/rwaldron/johnny-five/blob/master/docs/led-slider.md)
+- [LED - Array](https://github.com/rwaldron/johnny-five/blob/master/docs/led-array.md)
+- [LED - RGB](https://github.com/rwaldron/johnny-five/blob/master/docs/led-rgb.md)
+- [LED - RGB (Common Anode)](https://github.com/rwaldron/johnny-five/blob/master/docs/led-rgb-anode.md)
+- [LED - RGB (Common Anode) PCA9685](https://github.com/rwaldron/johnny-five/blob/master/docs/led-rgb-anode-PCA9685.md)
+- [LED - RGB Intensity](https://github.com/rwaldron/johnny-five/blob/master/docs/led-rgb-intensity.md)
+- [LED - Rainbow](https://github.com/rwaldron/johnny-five/blob/master/docs/led-rainbow.md)
+- [LED - Digital Clock](https://github.com/rwaldron/johnny-five/blob/master/docs/led-digits-clock.md)
+- [LED - Digital Clock, HT16K33](https://github.com/rwaldron/johnny-five/blob/master/docs/led-digits-clock-HT16K33.md)
+- [LED - Digital Clock, Dual Displays](https://github.com/rwaldron/johnny-five/blob/master/docs/led-digits-clock-dual.md)
+- [LED - Matrix](https://github.com/rwaldron/johnny-five/blob/master/docs/led-matrix.md)
+- [LED - Matrix Demo](https://github.com/rwaldron/johnny-five/blob/master/docs/led-matrix-tutorial.md)
+- [LED - Matrix HT16K33](https://github.com/rwaldron/johnny-five/blob/master/docs/led-matrix-HT16K33.md)
+- [LED - Matrix HT16K33 16x8](https://github.com/rwaldron/johnny-five/blob/master/docs/led-matrix-HT16K33-16x8.md)
+- [LED - Draw Matrix Characters Demo](https://github.com/rwaldron/johnny-five/blob/master/docs/led-chars-demo.md)
+- [LED - Enumerate Matrix Characters & Symbols](https://github.com/rwaldron/johnny-five/blob/master/docs/led-enumeratechars.md)
+
+### Servo
+- [Servo](https://github.com/rwaldron/johnny-five/blob/master/docs/servo.md)
+- [Servo - PCA9685](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-PCA9685.md)
+- [Servo - Continuous](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-continuous.md)
+- [Servo - Slider control](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-slider.md)
+- [Servo - Prompt](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-prompt.md)
+- [Servo - Drive](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-drive.md)
+- [Servo - Sweep](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-sweep.md)
+- [Servo - Array of servos](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-array.md)
+
+### Servo Animation
+- [Servo - Animation](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-animation.md)
+- [Servo - Leg Animation](https://github.com/rwaldron/johnny-five/blob/master/docs/servo-animation-leg.md)
+
+### Color
+- [Color - EVShield EV3 (Code)](https://github.com/rwaldron/johnny-five/blob/master/docs/color-EVS_EV3.md)
+- [Color - EVShield EV3 (Raw)](https://github.com/rwaldron/johnny-five/blob/master/docs/color-raw-EVS_EV3.md)
+- [Color - EVShield NXT (Code)](https://github.com/rwaldron/johnny-five/blob/master/docs/color-EVS_NXT.md)
+- [Color - ISL29125](https://github.com/rwaldron/johnny-five/blob/master/docs/color-ISL29125.md)
+
+### Motor
+- [Motor](https://github.com/rwaldron/johnny-five/blob/master/docs/motor.md)
+- [Motor - Directional](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-directional.md)
+- [Motor - Brake](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-brake.md)
+- [Motor - Current](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-current.md)
+- [Motor - H-Bridge](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-hbridge.md)
+- [Motor - PCA9685](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-PCA9685.md)
+- [Motor - LUDUS](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-LUDUS.md)
+- [Motor - 3 pin](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-3-pin.md)
+- [Motor - EVShield EV3](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-EVS_EV3.md)
+- [Motor - EVShield NXT](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-EVS_NXT.md)
+
+### Stepper Motor
+- [Stepper - Driver](https://github.com/rwaldron/johnny-five/blob/master/docs/stepper-driver.md)
+- [Stepper - Sweep](https://github.com/rwaldron/johnny-five/blob/master/docs/stepper-sweep.md)
+
+### ESC & Brushless Motor
+- [ESC - Keypress](https://github.com/rwaldron/johnny-five/blob/master/docs/esc-keypress.md)
+- [ESC - Dualshock](https://github.com/rwaldron/johnny-five/blob/master/docs/esc-dualshock.md)
+- [ESC - PCA9685](https://github.com/rwaldron/johnny-five/blob/master/docs/esc-PCA9685.md)
+- [ESC - Bidirectional](https://github.com/rwaldron/johnny-five/blob/master/docs/esc-bidirectional.md)
+- [ESC - Bidirectional Forward-Reverse](https://github.com/rwaldron/johnny-five/blob/master/docs/esc-bidirectional-forward-reverse.md)
+
+### Button / Switch
+- [Button](https://github.com/rwaldron/johnny-five/blob/master/docs/button.md)
+- [Button - Bumper](https://github.com/rwaldron/johnny-five/blob/master/docs/button-bumper.md)
+- [Button - Options](https://github.com/rwaldron/johnny-five/blob/master/docs/button-options.md)
+- [Button - Pullup](https://github.com/rwaldron/johnny-five/blob/master/docs/button-pullup.md)
+- [Toggle Switch](https://github.com/rwaldron/johnny-five/blob/master/docs/toggle-switch.md)
+- [Button - EVShield EV3](https://github.com/rwaldron/johnny-five/blob/master/docs/button-EVS_EV3.md)
+- [Button - EVShield NXT](https://github.com/rwaldron/johnny-five/blob/master/docs/button-EVS_NXT.md)
+
+### Keypad
+- [Keypad - VKEY](https://github.com/rwaldron/johnny-five/blob/master/docs/keypad-analog-vkey.md)
+- [Keypad - Waveshare AD](https://github.com/rwaldron/johnny-five/blob/master/docs/keypad-analog-ad.md)
+- [Keypad - MPR121](https://github.com/rwaldron/johnny-five/blob/master/docs/keypad-MPR121.md)
+- [Keypad - MPR121QR2](https://github.com/rwaldron/johnny-five/blob/master/docs/keypad-MPR121QR2.md)
+
+### Relay
+- [Relay](https://github.com/rwaldron/johnny-five/blob/master/docs/relay.md)
+
+### Shift Register
+- [Shift Register](https://github.com/rwaldron/johnny-five/blob/master/docs/shift-register.md)
+- [Shift Register - Seven segment controller](https://github.com/rwaldron/johnny-five/blob/master/docs/shift-register-seven-segment.md)
+- [Shift Register - Seven segments, daisy chained](https://github.com/rwaldron/johnny-five/blob/master/docs/shift-register-daisy-chain.md)
+
+### Infrared Reflectance)
+- [IR Motion](https://github.com/rwaldron/johnny-five/blob/master/docs/ir-motion.md)
+- [IR Proximity](https://github.com/rwaldron/johnny-five/blob/master/docs/ir-proximity.md)
+- [IR Reflectance](https://github.com/rwaldron/johnny-five/blob/master/docs/ir-reflect.md)
+- [IR Reflectance Array](https://github.com/rwaldron/johnny-five/blob/master/docs/ir-reflect-array.md)
+
+### Proximity
+- [Proximity](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity.md)
+- [Proximity - GP2Y0A710K0F](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-GP2Y0A710K0F.md)
+- [Proximity - SRF10](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-srf10.md)
+- [Proximity - MB1000](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-mb1000.md)
+- [Proximity - MB1010](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-mb1010.md)
+- [Proximity - MB1003](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-mb1003.md)
+- [Proximity - MB1230](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-mb1230.md)
+- [Proximity - HC-SR04](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-hcsr04.md)
+- [Proximity - LIDAR-Lite](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-lidarlite.md)
+- [Proximity - EVShield EV3 (IR)](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-EVS_EV3_IR.md)
+- [Proximity - EVShield EV3 (Ultrasonic)](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-EVS_EV3_US.md)
+- [Proximity - EVShield EV3 (IR)](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-EVS_EV3_IR-alert.md)
+- [Proximity - EVShield EV3 (Ultrasonic)](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-EVS_EV3_US-alert.md)
+
+### Motion
+- [Motion](https://github.com/rwaldron/johnny-five/blob/master/docs/motion.md)
+- [Motion - GP2Y0D805Z0F](https://github.com/rwaldron/johnny-five/blob/master/docs/motion-gp2y0d805z0f.md)
+- [Motion - GP2Y0D810Z0F](https://github.com/rwaldron/johnny-five/blob/master/docs/motion-gp2y0d810z0f.md)
+- [Motion - GP2Y0D810Z0F](https://github.com/rwaldron/johnny-five/blob/master/docs/motion-gp2y0d815z0f.md)
+- [Motion - GP2Y0A60SZLF](https://github.com/rwaldron/johnny-five/blob/master/docs/motion-GP2Y0A60SZLF.md)
+
+### Joystick
+- [Joystick](https://github.com/rwaldron/johnny-five/blob/master/docs/joystick.md)
+- [Joystick - Esplora](https://github.com/rwaldron/johnny-five/blob/master/docs/joystick-esplora.md)
+- [Joystick - Sparkfun Shield](https://github.com/rwaldron/johnny-five/blob/master/docs/joystick-shield.md)
+- [Joystick - Pan + Tilt control](https://github.com/rwaldron/johnny-five/blob/master/docs/joystick-pantilt.md)
+
+### LCD
+- [LCD](https://github.com/rwaldron/johnny-five/blob/master/docs/lcd.md)
+- [LCD - Enumerate characters](https://github.com/rwaldron/johnny-five/blob/master/docs/lcd-enumeratechars.md)
+- [LCD - Runner 20x4](https://github.com/rwaldron/johnny-five/blob/master/docs/lcd-runner-20x4.md)
+- [LCD - Runner 16x2](https://github.com/rwaldron/johnny-five/blob/master/docs/lcd-runner.md)
+- [LCD - I2C](https://github.com/rwaldron/johnny-five/blob/master/docs/lcd-i2c.md)
+- [LCD - I2C PCF8574](https://github.com/rwaldron/johnny-five/blob/master/docs/lcd-i2c-PCF8574.md)
+- [LCD - I2C Runner](https://github.com/rwaldron/johnny-five/blob/master/docs/lcd-i2c-runner.md)
+
+### Compass/Magnetometer
+- [Compass / Magnetometer](https://github.com/rwaldron/johnny-five/blob/master/docs/magnetometer.md)
+- [Compass - HMC6352](https://github.com/rwaldron/johnny-five/blob/master/docs/compass-hmc6352.md)
+- [Compass - HMC5883L](https://github.com/rwaldron/johnny-five/blob/master/docs/compass-hmc5883l.md)
+- [Compass - Logger](https://github.com/rwaldron/johnny-five/blob/master/docs/magnetometer-log.md)
+- [Compass - Find north](https://github.com/rwaldron/johnny-five/blob/master/docs/magnetometer-north.md)
+
+### Piezo
+- [Piezo](https://github.com/rwaldron/johnny-five/blob/master/docs/piezo.md)
+
+### IMU/Multi
+- [IMU - MPU6050](https://github.com/rwaldron/johnny-five/blob/master/docs/imu-mpu6050.md)
+- [Multi - MPL115A2](https://github.com/rwaldron/johnny-five/blob/master/docs/multi-mpl115a2.md)
+- [Multi - MPL3115A2](https://github.com/rwaldron/johnny-five/blob/master/docs/multi-mpl3115a2.md)
+- [Multi - BMP180](https://github.com/rwaldron/johnny-five/blob/master/docs/multi-bmp180.md)
+- [Multi - HTU21D](https://github.com/rwaldron/johnny-five/blob/master/docs/multi-htu21d.md)
+
+### Sensors
+- [Sensor](https://github.com/rwaldron/johnny-five/blob/master/docs/sensor.md)
+- [Sensor - Slide potentiometer](https://github.com/rwaldron/johnny-five/blob/master/docs/sensor-slider.md)
+- [Sensor - Force sensitive resistor](https://github.com/rwaldron/johnny-five/blob/master/docs/sensor-fsr.md)
+- [Sensor - Photoresistor](https://github.com/rwaldron/johnny-five/blob/master/docs/photoresistor.md)
+- [Sensor - Potentiometer](https://github.com/rwaldron/johnny-five/blob/master/docs/potentiometer.md)
+- [Sensor - Microphone](https://github.com/rwaldron/johnny-five/blob/master/docs/microphone.md)
+- [Accelerometer](https://github.com/rwaldron/johnny-five/blob/master/docs/accelerometer.md)
+- [Accelerometer - ADXL345](https://github.com/rwaldron/johnny-five/blob/master/docs/accelerometer-adxl345.md)
+- [Accelerometer - ADXL335](https://github.com/rwaldron/johnny-five/blob/master/docs/accelerometer-adxl335.md)
+- [Accelerometer - MMA7361](https://github.com/rwaldron/johnny-five/blob/master/docs/accelerometer-mma7361.md)
+- [Accelerometer - MPU6050](https://github.com/rwaldron/johnny-five/blob/master/docs/accelerometer-mpu6050.md)
+- [Accelerometer - Pan + Tilt](https://github.com/rwaldron/johnny-five/blob/master/docs/accelerometer-pan-tilt.md)
+- [Gyro](https://github.com/rwaldron/johnny-five/blob/master/docs/gyro.md)
+- [Gyro - Analog LPR5150AL](https://github.com/rwaldron/johnny-five/blob/master/docs/gyro-lpr5150l.md)
+- [Gyro - I2C MPU6050](https://github.com/rwaldron/johnny-five/blob/master/docs/gyro-mpu6050.md)
+- [Temperature - TMP36](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-tmp36.md)
+- [Temperature - TMP102](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-tmp102.md)
+- [Temperature - LM35](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-lm35.md)
+- [Temperature - LM335](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-lm335.md)
+- [Temperature - DS18B20](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-ds18b20.md)
+- [Temperature - MPU6050](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-mpu6050.md)
+- [Temperature - HTU21D](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-htu21d.md)
+- [Barometer - MPL115A2](https://github.com/rwaldron/johnny-five/blob/master/docs/barometer-mpl115a2.md)
+- [Barometer - MPL3115A2](https://github.com/rwaldron/johnny-five/blob/master/docs/barometer-mpl3115a2.md)
+- [Altimeter - MPL3115A2](https://github.com/rwaldron/johnny-five/blob/master/docs/altimeter-mpl3115a2.md)
+- [Temperature - MPL3115A2](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-mpl3115a2.md)
+- [Temperature - MPL115A2](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-mpl115a2.md)
+- [Barometer - BMP180](https://github.com/rwaldron/johnny-five/blob/master/docs/barometer-BMP180.md)
+- [Hygrometer - HTU21D](https://github.com/rwaldron/johnny-five/blob/master/docs/hygrometer-htu21d.md)
+- [Temperature - BMP180](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-BMP180.md)
+- [Temperature - SI7020](https://github.com/rwaldron/johnny-five/blob/master/docs/temperature-SI7020.md)
+
+### Photon Weather Shield
+- [Photon Weather Shield: Moisture](https://github.com/rwaldron/johnny-five/blob/master/docs/sensor-photon-weather-shield-moisture.md)
+
+### Lego EVShield
+- [Button - EVShield EV3](https://github.com/rwaldron/johnny-five/blob/master/docs/button-EVS_EV3.md)
+- [Button - EVShield NXT](https://github.com/rwaldron/johnny-five/blob/master/docs/button-EVS_NXT.md)
+- [Color - EVShield EV3 (Code)](https://github.com/rwaldron/johnny-five/blob/master/docs/color-EVS_EV3.md)
+- [Color - EVShield EV3 (Raw)](https://github.com/rwaldron/johnny-five/blob/master/docs/color-raw-EVS_EV3.md)
+- [Color - EVShield NXT (Code)](https://github.com/rwaldron/johnny-five/blob/master/docs/color-EVS_NXT.md)
+- [Light - EVShield EV3 (Ambient)](https://github.com/rwaldron/johnny-five/blob/master/docs/light-ambient-EVS_EV3.md)
+- [Light - EVShield NXT (Ambient)](https://github.com/rwaldron/johnny-five/blob/master/docs/light-ambient-EVS_NXT.md)
+- [Light - EVShield EV3 (Reflected)](https://github.com/rwaldron/johnny-five/blob/master/docs/light-reflected-EVS_EV3.md)
+- [Light - EVShield NXT (Reflected)](https://github.com/rwaldron/johnny-five/blob/master/docs/light-reflected-EVS_NXT.md)
+- [Motor - EVShield EV3](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-EVS_EV3.md)
+- [Motor - EVShield NXT](https://github.com/rwaldron/johnny-five/blob/master/docs/motor-EVS_NXT.md)
+- [Proximity - EVShield EV3 (IR)](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-EVS_EV3_IR-alert.md)
+- [Proximity - EVShield EV3 (Ultrasonic)](https://github.com/rwaldron/johnny-five/blob/master/docs/proximity-EVS_EV3_US-alert.md)
+
+### Intel Edison + Grove IoT Kit
+- [Intel Edison + Grove - Accelerometer (ADXL346)](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-accelerometer-adxl345-edison.md)
+- [Intel Edison + Grove - Accelerometer (MMA7660)](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-accelerometer-mma7660-edison.md)
+- [Intel Edison + Grove - Barometer (BMP180)](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-barometer-edison.md)
+- [Intel Edison + Grove - Compass (HMC588L)](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-compass-edison.md)
+- [Intel Edison + Grove - Flame Sensor](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-flame-sensor-edison.md)
+- [Intel Edison + Grove - LED](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-led-edison.md)
+- [Intel Edison + Grove - Light Sensor (TSL2561)](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-light-sensor-edison.md)
+- [Intel Edison + Grove - Button](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-button-edison.md)
+- [Intel Edison + Grove - Moisture Sensor](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-moisture-edison.md)
+- [Intel Edison + Grove - Gas (MQ2)](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-gas-mq2-edison.md)
+- [Intel Edison + Grove - Air quality sensor](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-gas-tp401-edison.md)
+- [Intel Edison + Grove - Joystick](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-joystick-edison.md)
+- [Intel Edison + Grove - Rotary Potentiometer](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-rotary-potentiometer-edison.md)
+- [Intel Edison + Grove - RGB LCD](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-lcd-rgb-edison.md)
+- [Intel Edison + Grove - LCD RGB temperature display](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-lcd-rgb-temperature-display-edison.md)
+- [Intel Edison + Grove - Relay](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-relay-edison.md)
+- [Intel Edison + Grove - Servo](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-servo-edison.md)
+- [Intel Edison + Grove - Touch](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-touch-edison.md)
+
+### Grove IoT Kit (Seeed Studio)
+- [Grove - LED](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-led.md)
+- [Grove - Button](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-button.md)
+- [Grove - Touch](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-touch.md)
+- [Grove - Joystick](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-joystick.md)
+- [Grove - Rotary Potentiometer](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-rotary-potentiometer.md)
+- [Grove - RGB LCD](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-lcd-rgb.md)
+- [Grove - LCD RGB temperature display](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-lcd-rgb-temperature-display.md)
+- [Grove - Servo](https://github.com/rwaldron/johnny-five/blob/master/docs/grove-servo.md)
+
+### Micro Magician V2
+- [Micro Magician V2 - Accelerometer](https://github.com/rwaldron/johnny-five/blob/master/docs/micromagician-accelerometer.md)
+- [Micro Magician V2 - Motor](https://github.com/rwaldron/johnny-five/blob/master/docs/micromagician-motor.md)
+- [Micro Magician V2 - Servo](https://github.com/rwaldron/johnny-five/blob/master/docs/micromagician-servo.md)
+
+### TinkerKit
+- [TinkerKit - Accelerometer](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-accelerometer.md)
+- [TinkerKit - Blink](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-blink.md)
+- [TinkerKit - Button](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-button.md)
+- [TinkerKit - Combo](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-combo.md)
+- [TinkerKit - Continuous servo](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-continuous-servo.md)
+- [TinkerKit - Gyro](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-gyroscope.md)
+- [TinkerKit - Joystick](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-joystick.md)
+- [TinkerKit - Linear potentiometer](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-linear-pot.md)
+- [TinkerKit - Rotary potentiometer](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-rotary.md)
+- [TinkerKit - Temperature](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-thermistor.md)
+- [TinkerKit - Tilt](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-tilt.md)
+- [TinkerKit - Touch](https://github.com/rwaldron/johnny-five/blob/master/docs/tinkerkit-touch.md)
+
+### Wii
+- [Wii Nunchuck](https://github.com/rwaldron/johnny-five/blob/master/docs/nunchuk.md)
+- [Wii Classic Controller](https://github.com/rwaldron/johnny-five/blob/master/docs/classic-controller.md)
+
+### Complete Bots / Projects
+- [Line Follower](https://github.com/rwaldron/johnny-five/blob/master/docs/line-follower.md)
+- [Motobot](https://github.com/rwaldron/johnny-five/blob/master/docs/motobot.md)
+- [Navigator](https://github.com/rwaldron/johnny-five/blob/master/docs/navigator.md)
+- [Nodebot](https://github.com/rwaldron/johnny-five/blob/master/docs/nodebot.md)
+- [Whisker](https://github.com/rwaldron/johnny-five/blob/master/docs/whisker.md)
+- [Phoenix Hexapod](https://github.com/rwaldron/johnny-five/blob/master/docs/phoenix.md)
+- [BOE Bot](https://github.com/rwaldron/johnny-five/blob/master/docs/boe-test-servos.md)
+- [Bug](https://github.com/rwaldron/johnny-five/blob/master/docs/bug.md)
+- [Lynxmotion Biped BRAT](https://github.com/rwaldron/johnny-five/blob/master/docs/brat.md)
+- [Robotic Claw](https://github.com/rwaldron/johnny-five/blob/master/docs/claw.md)
+- [Kinect Robotic Arm Controller](https://github.com/rwaldron/johnny-five/blob/master/docs/kinect-arm-controller.md)
+- [Laser Trip Wire](https://github.com/rwaldron/johnny-five/blob/master/docs/laser-trip-wire.md)
+- [Radar](https://github.com/rwaldron/johnny-five/blob/master/docs/radar.md)
+
+### Component Plugin Template
+- [Example plugin](https://github.com/rwaldron/johnny-five/blob/master/docs/plugin.md)
+
+### IO Plugins
+- [Led Blink on Electric Imp](https://github.com/rwaldron/johnny-five/blob/master/docs/imp-io.md)
+- [Led Blink on Spark Core](https://github.com/rwaldron/johnny-five/blob/master/docs/spark-io.md)
+- [Led Blink on pcDuino3](https://github.com/rwaldron/johnny-five/blob/master/docs/pcduino-io.md)
+- [Led Blink on Intel Galileo Gen 2](https://github.com/rwaldron/johnny-five/blob/master/docs/galileo-io.md)
+- [Led Blink on Raspberry Pi](https://github.com/rwaldron/johnny-five/blob/master/docs/raspi-io.md)
+- [Led Blink on Intel Edison Arduino Board](https://github.com/rwaldron/johnny-five/blob/master/docs/edison-io-arduino.md)
+- [Led Blink on Intel Edison Mini Board](https://github.com/rwaldron/johnny-five/blob/master/docs/edison-io-miniboard.md)
+
+<!--extract-end:examples-->
+
+## Many fragments. Some large, some small.
+
+#### [Wireless Nodebot](http://jsfiddle.net/rwaldron/88M6b/show/light)
+#### [Kinect Controlled Robot Arm](http://jsfiddle.net/rwaldron/XMsGQ/show/light/)
+#### [Biped Nodebot](http://jsfiddle.net/rwaldron/WZkn5/show/light/)
+#### [LCD Running Man](http://jsfiddle.net/rwaldron/xKwaU/show/light/)
+#### [Slider Controlled Panning Servo](http://jsfiddle.net/rwaldron/kZakv/show/light/)
+#### [Joystick Controlled Laser (pan/tilt) 1](http://jsfiddle.net/rwaldron/HPqms/show/light/)
+#### [Joystick Controlled Laser (pan/tilt) 2](http://jsfiddle.net/rwaldron/YHb7A/show/light/)
+#### [Joystick Controlled Claw](http://jsfiddle.net/rwaldron/6ZXFe/show/light/)
+#### [Robot Claw](http://jsfiddle.net/rwaldron/CFSZJ/show/light/)
+#### [Joystick, Motor & Led](http://jsfiddle.net/rwaldron/gADSz/show/light/)
+
+
+
+## Make: JavaScript Robotics
+
+[![](http://ecx.images-amazon.com/images/I/91ae8ZZDQ2L.jpg)](http://shop.oreilly.com/product/0636920031390.do)
+
+
+
+
+## Contributing
+All contributions must adhere to the [Idiomatic.js Style Guide](https://github.com/rwaldron/idiomatic.js),
+by maintaining the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [grunt](https://github.com/gruntjs/grunt).
+
+
+## License
+Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
+Licensed under the MIT license.
+Copyright (c) 2014, 2015 The Johnny-Five Contributors
+Licensed under the MIT license.

--- a/test/fixtures/readmes/maintenance-modules.md
+++ b/test/fixtures/readmes/maintenance-modules.md
@@ -1,0 +1,33 @@
+# maintenance-modules
+
+[![NPM](https://nodei.co/npm/maintenance-modules.png)](https://nodei.co/npm/maintenance-modules/)
+
+There is no code in this module, the only thing is this README file.
+
+This is a list of modules that are useful for maintaining or developing modules.
+
+- https://github.com/henrikjoreteg/fixpack
+- https://github.com/feross/standard
+- https://github.com/maxogden/dependency-check
+- https://github.com/finnp/create-module
+- https://github.com/finnp/node-travisjs
+- https://github.com/meandavejustice/gh-pages-deploy
+- https://github.com/phuu/npm-release
+- https://github.com/tjunnone/npm-check-updates
+- https://github.com/zeke/npe
+- https://github.com/zeke/package-json-to-readme
+- https://github.com/zeke/npmwd
+- https://github.com/twolfson/foundry
+- https://github.com/boennemann/semantic-release
+
+## maintenance bash scripts
+
+```
+alias patch='pre-version && npm version patch && post-version'
+alias minor='pre-version && npm version minor && post-version'
+alias major='pre-version && npm version major && post-version'
+alias pre-version='git diff --exit-code && npm prune && npm install -q && npm test'
+alias post-version='(npm run build; exit 0) && git diff --exit-code && git push && git push --tags && npm publish'
+```
+
+- https://gist.github.com/sindresorhus/8435329

--- a/test/fixtures/readmes/memoize.md
+++ b/test/fixtures/readmes/memoize.md
@@ -1,0 +1,78 @@
+memoize
+=======
+memoize caches your callbacks given a set of arguments
+
+Installation
+------------
+    npm install memoize
+
+Usage
+-----
+```javascript
+memoize(<object or function to memoize>, [expire time in ms], [array of methods to memoize], [options object])
+```
+
+Arguments after the 1st one can be passed in any order.
+
+Available options (defaults shown):
+
+```javascript
+{
+  expire  : 30000,  // Expire time in ms (false to never expire)
+  exclude : [],     // Array of methods to exclude from memoizing
+  only    : [],     // Array of methods to memoize only
+  error   : true,   // If false, ignore errors and memoize anyway. Useful if your function doesn't callback an error
+  debug   : false,  // Debugging
+  store   : new MemoryStore()   // Storage engine to use - required methods: get, set, clear
+}
+```
+
+You can set global options using `memoize.set(key, value)` or `memoize.set(options object)`.
+If you wish to retrieve a value use `memoize.get(key)`
+
+To force expiration of all stored memoized values: `memoize.clear(memoized object)`
+
+Examples
+--------
+
+```javascript
+var memoize = require('memoize')
+
+var date = memoize(function(seed, cb) {
+  setTimeout(function() {
+    cb(null, Date.now())
+  }, 100)
+})
+
+date(1, function(err, d1) { // given a set of arguments
+  console.log(d1) // 1304606051552
+  date(1, function(err, d2) { // same arguments
+    console.log(d2) // 1304606051552  cached! same results
+    date(2, function(err, d3) { // we changed the arguments
+      console.log(d3) // 1304606051652  so it's different
+    })
+  })
+})
+```
+
+also entire objects:
+
+```javascript
+var memoize = require('memoize')
+  , redis = memoize('myobject', require('redis').createClient(), { exclude: [ 'set' ] })
+
+redis.set('foo', 'bar', function(err) {
+  redis.get('foo', function(err, res) {
+    console.log(res) // 'bar'
+    redis.set('foo', 'zoo', function(err) {
+      redis.get('foo', function(err, res) {
+        console.log(res) // still 'bar', hasn't expired yet!
+      })
+    })
+  })
+})
+```
+
+Todo
+----
+Better tests

--- a/test/fixtures/readmes/mkhere.md
+++ b/test/fixtures/readmes/mkhere.md
@@ -1,0 +1,27 @@
+# mkhere
+
+Command line utility used to create files based on pre-defined templates
+
+[![NPM](https://nodei.co/npm/mkhere.png)](https://nodei.co/npm/mkhere/)
+
+### Usage
+
+    --------------------------------------------------
+    mkhere: Create files based on predefined templates
+    --------------------------------------------------
+
+    Run: mkhere init
+             To create .templates directory within your home containing sample templates.
+    Run: mkhere list
+             To list all templates in /home/sasha/.templates
+    Run: mkhere tplname.html newname
+             This will create new file newname.html based on /home/sasha/.templates/tplname.html in current directory
+    Run: mkhere html.html ~/Desktop/sa
+             This will create new file sa.html based on /home/sasha/.templates/html.html on the desktop
+
+    ------------------Auto-completion-----------------
+
+    Run: mkhere --completion >> ~/.mkhere.completion.sh && echo 'source ~/.mkhere.completion.sh' >> ~/.bashrc
+            In order to enable auto-completion in your `BASH` terminal
+    Or: echo '. <(./mkhere --completion)' >> .zshrc
+            if you're using `ZSH`

--- a/test/fixtures/readmes/payform.md
+++ b/test/fixtures/readmes/payform.md
@@ -1,0 +1,242 @@
+# payform
+
+[![Build Status](https://travis-ci.org/jondavidjohn/payform.svg?branch=master)](https://travis-ci.org/jondavidjohn/payform)
+![Dependencies](https://david-dm.org/jondavidjohn/payform.svg)
+
+[![NPM](https://nodei.co/npm/payform.png)](https://npmjs.org/package/payform)
+
+A general purpose library for building credit card forms, validating inputs, and formatting numbers.
+
+Available via **NPM** (Node or Browserify) and **Bower**.
+
+For example, you can make a input act like a credit card field (with number formatting and length restriction):
+
+``` javascript
+var input = document.getElementById('ccnum');
+payform.cardNumberInput(input);
+```
+
+Then, when the payment form is submitted, you can validate the card number on the client-side (or server-side):
+
+``` javascript
+var valid = payform.validateCardNumber(input.value);
+
+if (!valid) {
+  alert('Your card is not valid!');
+  return false;
+}
+```
+
+You can find a [demo here](http://jondavidjohn.github.io/payform).
+
+Supported card types are:
+
+* Visa
+* MasterCard
+* American Express
+* Diners Club
+* Discover
+* UnionPay
+* JCB
+* Visa Electron
+* Maestro
+* Forbrugsforeningen
+* Dankort
+
+(Additional card types are supported by extending the [`payform.cards`](#payformcards) array.)
+
+## API
+
+### payform.validateCardNumber(number)
+
+Validates a card number:
+
+* Validates numbers
+* Validates Luhn algorithm
+* Validates length
+
+Example:
+
+``` javascript
+payform.validateCardNumber('4242 4242 4242 4242'); //=> true
+```
+
+### payform.validateCardExpiry(month, year)
+
+Validates a card expiry:
+
+* Validates numbers
+* Validates in the future
+* Supports year shorthand
+
+Example:
+
+``` javascript
+payform.validateCardExpiry('05', '20'); //=> true
+payform.validateCardExpiry('05', '2015'); //=> true
+payform.validateCardExpiry('05', '05'); //=> false
+```
+
+### payform.validateCardCVC(cvc, type)
+
+Validates a card CVC:
+
+* Validates number
+* Validates length to 4
+
+Example:
+
+``` javascript
+payform.validateCardCVC('123'); //=> true
+payform.validateCardCVC('123', 'amex'); //=> true
+payform.validateCardCVC('1234', 'amex'); //=> true
+payform.validateCardCVC('12344'); //=> false
+```
+
+### payform.parseCardType(number)
+
+Returns a card type. Either:
+
+* `visa`
+* `mastercard`
+* `amex`
+* `dinersclub`
+* `discover`
+* `unionpay`
+* `jcb`
+* `visaelectron`
+* `maestro`
+* `forbrugsforeningen`
+* `dankort`
+
+The function will return `null` if the card type can't be determined.
+
+Example:
+
+``` javascript
+payform.parseCardType('4242 4242 4242 4242'); //=> 'visa'
+```
+
+### payform.parseCardExpiry(string)
+
+Parses a credit card expiry in the form of MM/YYYY, returning an object containing the `month` and `year`. Shorthand years, such as `13` are also supported (and converted into the longhand, e.g. `2013`).
+
+``` javascript
+payform.parseCardExpiry('03 / 2025'); //=> {month: 3: year: 2025}
+payform.parseCardExpiry('05 / 04'); //=> {month: 5, year: 2004}
+```
+
+This function doesn't perform any validation of the month or year; use `payform.validateCardExpiry(month, year)` for that.
+
+### payform.cards
+
+Array of objects that describe valid card types. Each object should contain the following fields:
+
+``` javascript
+{
+  // Card type, as returned by payform.parseCardType.
+  type: 'mastercard',
+  // Regex used to identify the card type. For the best experience, this should be
+  // the shortest pattern that can guarantee the card is of a particular type.
+  pattern: /^5[0-5]/,
+  // Array of valid card number lengths.
+  length: [16],
+  // Array of valid card CVC lengths.
+  cvcLength: [3],
+  // Boolean indicating whether a valid card number should satisfy the Luhn check.
+  luhn: true,
+  // Regex used to format the card number. Each match is joined with a space.
+  format: /(\d{1,4})/g
+}
+```
+
+When identifying a card type, the array is traversed in order until the card number matches a `pattern`. For this reason, patterns with higher specificity should appear towards the beginning of the array.
+
+## Browser `<input>` Helpers
+
+These methods are specifically for use in the browser to attach `<input>` formatters.
+
+### payform.cardNumberInput(input)
+
+Formats card numbers:
+
+* Includes a space between every 4 digits
+* Restricts input to numbers
+* Limits to 16 numbers
+* Supports American Express formatting
+
+Example:
+
+``` javascript
+var input = document.getElementById('ccnum');
+payform.cardNumberInput(input);
+```
+
+### payform.expiryInput(input)
+
+Formats card expiry:
+
+* Includes a `/` between the month and year
+* Restricts input to numbers
+* Restricts length
+
+Example:
+
+``` javascript
+var input = document.getElementById('ccnum');
+payform.expiryInput(input);
+```
+
+### payform.cvcInput(input)
+
+Formats card CVC:
+
+* Restricts length to 4 numbers
+* Restricts input to numbers
+
+Example:
+
+``` javascript
+var input = document.getElementById('ccnum');
+payform.cvcInput(input);
+```
+
+## Building
+
+Run `npm run build`
+
+## Running tests
+
+Run `npm test`
+
+## Autocomplete recommendations
+
+We recommend you turn autocomplete on for credit card forms, except for the CVC field (which should never be stored). You can do this by setting the `autocomplete` attribute:
+
+``` html
+<form autocomplete="on">
+  <input class="cc-number">
+  <input class="cc-cvc" autocomplete="off">
+</form>
+```
+
+You should also mark up your fields using the [Autofill spec](https://html.spec.whatwg.org/multipage/forms.html#autofill). These are respected by a number of browsers, including Chrome.
+
+``` html
+<input type="tel" class="cc-number" autocomplete="cc-number">
+```
+
+Set `autocomplete` to `cc-number` for credit card numbers and `cc-exp` for credit card expiry.
+
+## Mobile recommendations
+
+We recommend you to use `<input type="tel">` which will cause the numeric keyboard to be displayed on mobile devices:
+
+``` html
+<input type="tel" class="cc-number">
+```
+
+## A derived work
+
+This library is derived from a lot of great work done on [`jquery.payment`](https://github.com/stripe/jquery.payment) by the folks at [Stripe](https://stripe.com/).  This aims to
+build upon that work, in a module that can be consumed more easily with node/npm/browserify and without dependencies.

--- a/test/fixtures/readmes/wzrd.md
+++ b/test/fixtures/readmes/wzrd.md
@@ -1,0 +1,67 @@
+# wzrd
+
+Super minimal browserify development server. Inspired by [beefy](http://npmjs.org/beefy) but with less magic
+
+[![Build Status](https://travis-ci.org/maxogden/wzrd.svg?branch=master)](https://travis-ci.org/maxogden/wzrd)
+
+## installation
+
+```
+npm install wzrd -g
+```
+
+**note** that you must have a copy of `browserify` installed as well. It can be either local (preferred) or global.
+
+```
+npm install browserify --save
+```
+
+## usage
+
+```
+wzrd app.js
+```
+
+This will start a local development server (default of `localhost:9966`) that serves all files in the current folder with the exception of `app.js`, which will be browserified instead. `wzrd` will spawn the command `browserify app.js` and send the output bundle back to the client.
+
+If no `index.html` is present in the directory you run `wzrd` in, one will be generated for you that has a `<script src='app.js'></script>` in it.
+
+### mappings
+
+You can also specify a mapping:
+
+```
+wzrd app.js:bundle.js
+```
+
+This means if a request to the server comes in for `bundle.js`, `wzrd` will run the command `browserify app.js` and serve that.
+
+### multiple entries
+
+```
+wzrd app.js:bundle.js foo.js:bar.js baz.js
+```
+
+### https
+
+```
+wzrd app.js --https
+```
+
+this will start a local https server (by default `https://localhost:4443`) and generate a self signed SSL certificate. You will get a certificate error in your browser, but if you ignore the error the app should load.
+
+### passing extra args to browserify
+
+```
+wzrd app.js -- -t brfs
+```
+
+anything after `--` will get passed directly to `browserify` as arguments. so the example above would spawn the command `browserify app.js -t brfs`
+
+### pushstate server support
+
+```
+wzrd app.js --pushstate
+```
+
+if you want to leverage the html5 pushstate and support natural urls in your frontend application you can use the `--pushstate` flag. This flag will instruct the wzrd server to always return index.html for any file not found request from your server.

--- a/test/index.js
+++ b/test/index.js
@@ -478,17 +478,28 @@ describe('fixtures', function () {
     assert(keys.length)
     keys.forEach(function (key) {
       assert(fixtures[key])
-      if (key === 'packageNames') return
+      if (key === 'dependencies' || key === 'examples') return
       assert(typeof fixtures[key] === 'string')
     })
   })
 
   it('has a property that is an alphabetical list of dependencies', function () {
-    assert(Array.isArray(fixtures.packageNames))
-    assert(fixtures.packageNames.length)
+    assert(Array.isArray(fixtures.dependencies))
+    assert(fixtures.dependencies.length)
+  })
+
+  it('has a property that is an alphabetical list of saved examples', function () {
+    assert(Array.isArray(fixtures.examples))
+    assert(fixtures.examples.length)
   })
 
   it('includes some real package readmes right from node_modules', function () {
+    assert(fixtures.lodash.length)
+    assert(fixtures['property-ttl'].length)
+    assert(fixtures['sanitize-html'].length)
+  })
+
+  it('includes some real package readmes in static fixtures', function () {
     assert(fixtures.async.length)
     assert(fixtures.express.length)
     assert(fixtures['johnny-five'].length)
@@ -669,21 +680,30 @@ describe('cdn', function () {
 })
 
 describe('real readmes in the wild', function () {
-  it('parses readmes of all dependencies and devDependencies', function (done) {
-    var packages = fixtures.packageNames
-
+  function parsePackages (packages, done, getPackage) {
     assert(Array.isArray(packages))
     assert(packages.length)
     packages.forEach(function (name) {
       console.log('\t' + name)
       assert(typeof fixtures[name] === 'string')
-      var json = require(path.resolve('node_modules', name, 'package.json'))
-      var $ = marky(fixtures[name], {package: json})
+      var $ = marky(fixtures[name], {package: getPackage(name)})
       assert($.html().length > 100)
 
       if (name === packages[packages.length - 1]) {
         return done()
       }
+    })
+  }
+
+  it('parses all saved fixture readmes', function (done) {
+    parsePackages(fixtures.examples, done, function (name) {
+      return {name: name}
+    })
+  })
+
+  it('parses all dependency readmes', function (done) {
+    parsePackages(fixtures.dependencies, done, function (name) {
+      return require(path.resolve('node_modules', name, 'package.json'))
     })
   })
 


### PR DESCRIPTION
A bunch of our `devDependencies` are only included so we can use their README data as test fixtures. This commit adds their READMEs as static files we load separately during `npm test` and gets rid of their entries in `package.json`. As far as I can tell, we only need `mocha`, `standard`, and `glob` for actual development.

The overall testing strategy is similar to what we already have, except instead of loading all of the markdown strings in `fixtures.packageNames` we split them into `fixtures.dependencies` (which may be a poor name, since it *does* also include the `devDependencies` as well) and `fixtures.examples`. This allows us to differentiate them during test runs because we don't have to try to `require()` the static fixtures' packages; we can just mock them as `{name: name}`.

Unless there's more to this than I could glean just by reading the issue itself, this fixes #91.