### PR TITLE
Remove unused HTML comment remover

### DIFF
--- a/lib/comments.js
+++ b/lib/comments.js
@@ -1,4 +1,0 @@
-// Remove HTML comments so as not to confuse the markdown parser
-module.exports = function (html) {
-  return html.replace(/<!--[\s\S]*?-->/g, '')
-}


### PR DESCRIPTION
We have a tiny module `lib/comments.js` that strips HTML comments from its input, but we haven't been using it since [16696d2](https://github.com/npm/marky-markdown/commit/16696d206dd95e3594a0dbcdbf20271cffaa71d3) (and the `require()` for it was commented out in [6a80d2e](https://github.com/npm/marky-markdown/commit/6a80d2e0b553447d10fc012fd444b3e3e66d908f)). So here we finish the job and remove the file itself.