### PR TITLE
Convert leading tabs to spaces in fenced code blocks

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -5,6 +5,7 @@ var lazyHeaders = require('markdown-it-lazy-headers')
 var cleanup = require('./cleanup')
 var emoji = require('markdown-it-emoji')
 var codeWrap = require('./code-wrap')
+var expandTabs = require('markdown-it-expand-tabs')
 
 var highlighter = new Highlights()
 
@@ -50,6 +51,7 @@ module.exports = function (html, options) {
     .use(lazyHeaders)
     .use(emoji, {shortcuts: {}})
     .use(codeWrap)
+    .use(expandTabs, {tabWidth: 4})
   return parser.render(html)
 }
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "markdown-it": "^5.1.0",
     "markdown-it-lazy-headers": "^0.1.3",
     "markdown-it-emoji": "^1.1.0",
+    "markdown-it-expand-tabs": "^1.0.7",
     "property-ttl": "^1.0.0",
     "sanitize-html": "^1.6.1",
     "similarity": "^1.0.1"

--- a/test/fixtures/basic.md
+++ b/test/fixtures/basic.md
@@ -12,6 +12,14 @@ app.get('/', function (req, res) {
   res.send('Hello World')
 })
 
+app.get('/indenting', function (req, res) {
+	res.send('Hello World')
+	res.send('Hello Someone Else')
+	if (foo) {
+		// doubly indented
+	}
+})
+
 app.listen(3000)
 ```
 

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -71,6 +71,13 @@ describe('markdown processing and syntax highlighting', function () {
     assert(~$.html().indexOf('<span>&quot;</span>'))
   })
 
+  it('converts leading tabs in code blocks to spaces', function () {
+    var $ = marky(fixtures.basic)
+    var indentHtml = $('.highlight.js .line .comment span:not(.js)').html()
+    assert(!~indentHtml.indexOf('\t'))
+    assert(~indentHtml.indexOf('&#xA0;'))
+  })
+
   it('linkifies fully-qualified URLs', function () {
     assert(~fixtures['maintenance-modules'].indexOf('- https://gist.github.com/sindresorhus/8435329'))
     var $ = marky(fixtures['maintenance-modules'])


### PR DESCRIPTION
In #126 we have, among other things, a couple of rendering issues caused by the fact that [markdown-it](https://www.npmjs.com/package/markdown-it) (probably correctly) doesn't do anything with tab characters in fenced code blocks; *and* browsers render them with the traditional eight character width, and sometimes visually collapse sequential tabs into one. Neither of these behaviors matches what GitHub does, which appears to be four-space substitution per leading tab.

I couldn't find anything in the markdown-it plugin ecosystem that already covered this, so I built a markdown-it plugin called [markdown-it-expand-tabs](https://www.npmjs.com/package/markdown-it-expand-tabs) that we can use to help fix these rendering glitches. It's on NPM now, so this PR pulls it in and updates the `basic.md` test fixture to include some tab-indented code we can translate and inspect.