### PR TITLE
Remove final references to frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ npm test
 - [github-url-to-object](https://github.com/zeke/github-url-to-object): Extract user, repo, and other interesting properties from GitHub URLs
 - [highlights](https://github.com/atom/highlights): Syntax highlighter
 - [highlights-tokens](https://github.com/zeke/highlights-tokens): A list of the language tokens used by the Atom.app [highlights](https://www.npmjs.com/package/highlights) syntax highlighter
-- [html-frontmatter](https://github.com/zeke/html-frontmatter): Extract key-value metadata from HTML comments
 - [lodash](https://github.com/lodash/lodash): A utility library delivering consistency, customization, performance, &amp; extras.
 - [markdown-it](https://github.com/markdown-it/markdown-it): Markdown-it - modern pluggable markdown parser.
 - [markdown-it-emoji](https://github.com/markdown-it/markdown-it-emoji): Markdown-it-emoji extension for Markdown-it that parses markdown emoji syntax to unicode. 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "documentation",
     "syntax highlighting",
     "html",
-    "frontmatter",
     "github",
     "npm"
   ],


### PR DESCRIPTION
We still had `html-frontmatter` listed as a dependency in the README, and a `frontmatter` keyword in package.json, but those are out of date now, no? This commit cleans them up.