### PR TITLE
Add a line about :emoji: conversion to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The thing [npmjs.com](https://www.npmjs.com) uses to clean up READMEs and other 
 - Removes broken and malicious user input with [sanitize-html](https://www.npmjs.com/package/sanitize-html)
 - Applies syntax highlighting to [GitHub-flavored code blocks](https://help.github.com/articles/github-flavored-markdown/#fenced-code-blocks) using the [highlights](https://www.npmjs.com/package/highlights) library from [Atom](https://atom.io/).
 - Uses [cheerio](https://www.npmjs.com/package/cheerio) to perform various feats of DOM manipulation.
+- Converts `:emoji:`-style [shortcuts](http://www.emoji-cheat-sheet.com/) to unicode emojis.
 - Converts headings (h1, h2, etc) into anchored hyperlinks.
 - Converts relative GitHub links to their absolute equivalents.
 - Converts relative GitHub images sources to their GitHub raw equivalents.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The default options are as follows:
   prefixHeadingIds: true,     // prevent DOM id collisions
   serveImagesWithCDN: false,  // use npm's CDN to proxy images over HTTPS
   debug: false,               // console.log() all the things
-  package: null,              // npm package metadata
+  package: null               // npm package metadata
 }
 ```
 


### PR DESCRIPTION
I was thinking it might be appropriate to call out the `:emoji:` conversion we do, in the list describing what marky does.