### PR TITLE
Increase test coverage

### DIFF
--- a/lib/packagize.js
+++ b/lib/packagize.js
@@ -7,6 +7,7 @@ var markdown = require('markdown-it')({html: true})
 
 var packagize = module.exports = function ($, pkg) {
   if (!pkg) return $
+  if (!pkg.name) return $
 
   // mark first h1 if it closely matches pkg name
   var h1 = $('h1').first()

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "glob": "^6.0.4",
+    "intercept-stdout": "^0.1.2",
     "mocha": "^2.0.1",
     "standard": "^5.4.1"
   },

--- a/test/cdn.js
+++ b/test/cdn.js
@@ -5,6 +5,42 @@ var marky = require('..')
 var fixtures = require('./fixtures')
 
 describe('cdn', function () {
+  describe('handles missing or empty package data', function () {
+    var $
+
+    before(function () {
+      // generate a processed version with no CDN remapping, to use as a control
+      $ = marky(fixtures.basic)
+    })
+
+    it('skips CDN remap when lacking package data', function () {
+      var options = {
+        // leave package undefined
+        serveImagesWithCDN: true
+      }
+      var html = marky(fixtures.basic, options)
+      assert.equal(html.html(), $.html())
+    })
+
+    it('skips CDN remap when the package lacks a name', function () {
+      var options = {
+        package: {version: '1.0.0'},
+        serveImagesWithCDN: true
+      }
+      var html = marky(fixtures.basic, options)
+      assert.equal(html.html(), $.html())
+    })
+
+    it('skips CDN remap when the package lacks a version', function () {
+      var options = {
+        package: {name: 'foo'},
+        serveImagesWithCDN: true
+      }
+      var html = marky(fixtures.basic, options)
+      assert.equal(html.html(), $.html())
+    })
+  })
+
   describe('when serveImagesWithCDN is true', function () {
     var $
     var options = {

--- a/test/fixtures/github.md
+++ b/test/fixtures/github.md
@@ -37,3 +37,11 @@
 Smiley! :)
 
 :sparkles:
+
+<img src="" id='empty-src-img'/>
+
+<img id='no-src-img'/>
+
+<a href="" id='empty-href-link'>Link with empty href</a>
+
+<a id='no-href-link'>Link with no href</a>

--- a/test/marky.js
+++ b/test/marky.js
@@ -3,6 +3,7 @@
 var assert = require('assert')
 var marky = require('..')
 var fixtures = require('./fixtures')
+var intercept = require('intercept-stdout')
 
 describe('marky-markdown', function () {
   it('is a function', function () {
@@ -63,5 +64,18 @@ describe('fixtures', function () {
     assert(fixtures.async.length)
     assert(fixtures.express.length)
     assert(fixtures['johnny-five'].length)
+  })
+})
+
+describe('debug', function () {
+  it('produces the same output in debug mode as in normal mode', function () {
+    // drop anything going to stdout (so we don't wreck mocha's console output)
+    var unhookIntercept = intercept(function () { return "" })
+
+    var $ = marky(fixtures.benchmark)
+    var debug = marky(fixtures.benchmark, {debug: true})
+    assert.equal($.html(), debug.html())
+
+    unhookIntercept()
   })
 })


### PR DESCRIPTION
I decided to take a look at our test coverage to see if there were any substantial gaps, so I ran our tests through istanbul and found just a small handful of lines that weren't covered. The changes in this PR cover most of it.

**Please note that I didn't actually add the code coverage machinery.** It's certainly something we could do if everybody wanted to, but I was just after the data so I ran it as a one-off by doing `npm install istanbul` followed by `./node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- -R spec` and opening `./coverage/lcov-report/index.html` in a browser.

The changes:
- Probably the most important one is where our `packagize` module would error out if the package provided lacked a name (because it would try to do `pkg.name.replace(...)` on an undefined value). I added a quick `if()` guard
- We weren't fully testing that the `cdn` module would bail out if there wasn't sufficient package data supplied, so I added a few tests for that (this is what revealed the issue in `packagize`)
- Added a few lines to the `github.md` test fixture to make sure it properly handles `<img>` elements with a blank/missing `src` attribute and `<a>` elements with a blank/missing `href`
- Ensure running marky with `{debug: true}` produces the same output as normal execution

After these updates, the only code not covered by tests is in the `cleanup` module:

![screen shot 2016-02-03 at feb 3 2 13 33 pm](https://cloud.githubusercontent.com/assets/94850/12798816/67153d14-ca80-11e5-97b4-5b322ac0269d.png)

![screen shot 2016-02-03 at feb 3 2 12 12 pm](https://cloud.githubusercontent.com/assets/94850/12798779/34b6f1f0-ca80-11e5-9298-72d9b0e1098b.png)

![screen shot 2016-02-03 at feb 3 11 38 06 am](https://cloud.githubusercontent.com/assets/94850/12798761/0bd9a64c-ca80-11e5-9e0e-773d4df5d0f9.png)

That code never gets exercised in my normal development/testing cycle, but I suppose we could come up with a way to make it happen if you thought it was important enough. Everybody's got their own opinions about how important code coverage is, so I'll just defer to the majority.