### PR TITLE
update to standard@6.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "npm's markdown parser",
   "main": "index.js",
   "scripts": {
-    "test": "standard --format && mocha --timeout 5000"
+    "test": "standard-format -w && standard && mocha --timeout 5000"
   },
   "repository": {
     "type": "git",
@@ -52,7 +52,8 @@
   "devDependencies": {
     "glob": "^6.0.4",
     "mocha": "^2.0.1",
-    "standard": "^5.4.1"
+    "standard": "^6.0.4",
+    "standard-format": "^2.1.0"
   },
   "bin": "./bin/marky-markdown.js"
 }

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -9,10 +9,10 @@ var fixtures = {
 }
 
 // Read in all the hand-written fixture files
-fs.readdirSync(__dirname + '/fixtures').forEach(function (file) {
+fs.readdirSync(path.join(__dirname, 'fixtures')).forEach(function (file) {
   var key = path.basename(file).replace('.md', '')
   if (key !== path.basename(file)) { // skip anything lacking a .md extension
-    fixtures[key] = fs.readFileSync(__dirname + '/fixtures/' + file).toString()
+    fixtures[key] = fs.readFileSync(path.join(__dirname, 'fixtures', file)).toString()
   }
 })
 
@@ -34,10 +34,10 @@ fixtures.dependencies.forEach(function (name) {
 })
 
 // Read in all the sample readmes saved as fixtures
-fs.readdirSync(__dirname + '/fixtures/readmes').forEach(function (file) {
+fs.readdirSync(path.join(__dirname, 'fixtures', 'readmes')).forEach(function (file) {
   var key = path.basename(file).replace('.md', '')
   if (key !== path.basename(file)) { // skip anything lacking a .md extension
-    fixtures[key] = fs.readFileSync(__dirname + '/fixtures/readmes/' + file).toString()
+    fixtures[key] = fs.readFileSync(path.join(__dirname, 'fixtures', 'readmes', file)).toString()
     fixtures.examples.push(key)
   }
 })


### PR DESCRIPTION
Closes #139 
Closes #140 
Closes #141
Closes #142 
Closes #143 

Hello! This PR updates `marky-markdown` to the new major version of `standard`. 

The two notable updates for this repo are:
- `standard-format` must not be installed and used separately. Updated the test script to run it along with `standard`
- The file `fixtures.js` was updated to abide the new rule: 
  - `Use path.join() or path.resolve() instead of + to create paths. (no-path-concat)`

Cheers!