### PR TITLE
Disable linkification of raw .md/.name domains/hostnames

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -54,6 +54,10 @@ module.exports = function (html, options) {
     .use(codeWrap)
     .use(expandTabs, {tabWidth: 4})
     .use(githubHeadings, options)
+
+  parser.linkify.tlds('.md', false)
+  parser.linkify.tlds('.name', false)
+
   return parser.render(html)
 }
 

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -84,6 +84,11 @@ describe('markdown processing and syntax highlighting', function () {
     assert($("a[href='https://gist.github.com/sindresorhus/8435329']").length)
   })
 
+  it('does not linkify raw .md or .name domains/hostnames', function () {
+    var $ = marky('readme.md\nexample.name')
+    assert(!$('a').length)
+  })
+
   it('does not convert text emoticons to unicode', function () {
     assert(~fixtures.github.indexOf(':)'))
     var $ = marky(fixtures.github)


### PR DESCRIPTION
This change disables `.md` and `.name` domains/hostnames from being linkified by markdown-it's linkification code. Other than those two, it creates links from all other hosts under valid TLDs, same as before.