### PR TITLE
Remove extraneous code block wrapper customization code

### DIFF
--- a/lib/code-wrap.js
+++ b/lib/code-wrap.js
@@ -1,9 +1,4 @@
 var plugin = module.exports = function (md, options) {
-  var tag = plugin.defaultTag
-  if (options && options.tag) {
-    tag = options.tag
-  }
-
   // monkey patch the 'fence' parsing rule to restore markdown-it's pre-5.1 behavior
   // (see https://github.com/markdown-it/markdown-it/issues/190)
   var stockFenceRule = md.renderer.rules.fence
@@ -11,8 +6,8 @@ var plugin = module.exports = function (md, options) {
     // call the original rule first rather than inside the 'return' statement
     // because we need the 'class' attribute processing it does
     var output = stockFenceRule(tokens, idx, options, env, slf).trim()
-    return '<' + tag + slf.renderAttrs(tokens[idx]) + '>' + output + '</' + tag + '>\n'
+    return '<' + plugin.tag + slf.renderAttrs(tokens[idx]) + '>' + output + '</' + plugin.tag + '>\n'
   }
 }
 
-plugin.defaultTag = 'div'
+plugin.tag = 'div'


### PR DESCRIPTION
The highlighted code block wrapper plugin we wrote for markdown-it had the beginnings of support for customizing the wrapper tag, but there was no way to change it from consuming code, and no tests that covered using a custom tag. Since doing it would force users to skip the HTML sanitizing step (because anything other than a `div` will get filtered out), it seems just as well to remove that stuff for now.