### PR TITLE
hold github-url-to-object at 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "atom-language-nginx": "^0.4.0",
     "cheerio": "^0.20.0",
     "github-slugger": "^1.0.0",
-    "github-url-to-object": "^2.1.0",
+    "github-url-to-object": "2.1.0",
     "highlights": "^1.3.0",
     "highlights-tokens": "^1.0.1",
     "language-dart": "^0.1.1",


### PR DESCRIPTION
til we get #157 fixed. r? @revin