### PR TITLE
Skip wrapping fenced code blocks when highlightSyntax === false

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -52,9 +52,10 @@ module.exports = function (html, options) {
   var parser = MD(mdOptions)
     .use(lazyHeaders)
     .use(emoji, {shortcuts: {}})
-    .use(codeWrap)
     .use(expandTabs, {tabWidth: 4})
     .use(githubHeadings, options)
+
+  if (options.highlightSyntax) parser.use(codeWrap)
 
   return githubLinkify(parser).render(html)
 }

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -20,6 +20,13 @@ describe('markdown processing and syntax highlighting', function () {
     assert($('.highlight.js').length)
   })
 
+  it("omits code blocks' highlighting wrapper element when syntax highlighting is off", function () {
+    assert(~fixtures.basic.indexOf('```js'))
+    var $ = marky(fixtures.basic, {highlightSyntax: false})
+    assert(~$.html().indexOf('var express = require(&apos;express&apos;)'))
+    assert.equal($('.highlight').length, 0)
+  })
+
   it('adds js class to javascript blocks', function () {
     assert(~fixtures.basic.indexOf('```js'))
     assert($('.highlight.js').length)


### PR DESCRIPTION
Hey @ashleygwilliams if you agree with the premise from #162, then here's code that omits the fenced code block wrapper when syntax highlighting is off.

(I assume this would go in at the next major version bump)