### PR TITLE
Relaxed link reference definitions

### DIFF
--- a/lib/gfm/relaxed-link-reference.js
+++ b/lib/gfm/relaxed-link-reference.js
@@ -1,0 +1,24 @@
+module.exports = function (md, options) {
+  // Unfortunately, there's no public API for getting access to the existing
+  // installed parsing rules; rather than import the 'reference' rule directly
+  // from markdown-it just so we can re-install it into the parser with the
+  // 'alt' chain set up correctly, here we're just using internal utility
+  // methods to modify it in place at runtime.
+  //
+  // The net result is that we allow what are known in the CommonMark spec as
+  // "link reference definitions" to interrupt paragraphs, i.e., we relax the
+  // requirement that there be a blank line between a paragraph and a reference
+  // definition.
+  //
+  // That means that this works:
+  //
+  //   Some paragraph text here with a [linkref]
+  //   [linkref]: /actual/link/destination/here
+  //
+  // ...whereas spec compliance requires a blank line between the two.
+
+  var ruler = md.block.ruler
+  var idx = ruler.__find__('reference')
+  ruler.__rules__[idx].alt.push('paragraph')
+  ruler.__compile__()
+}

--- a/lib/render.js
+++ b/lib/render.js
@@ -8,6 +8,7 @@ var codeWrap = require('./code-wrap')
 var expandTabs = require('markdown-it-expand-tabs')
 var githubHeadings = require('./headings')
 var githubLinkify = require('./linkify')
+var relaxedLinkRefs = require('./gfm/relaxed-link-reference')
 
 var highlighter = new Highlights()
 
@@ -54,6 +55,7 @@ module.exports = function (html, options) {
     .use(emoji, {shortcuts: {}})
     .use(expandTabs, {tabWidth: 4})
     .use(githubHeadings, options)
+    .use(relaxedLinkRefs)
 
   if (options.highlightSyntax) parser.use(codeWrap)
 

--- a/test/fixtures/link-ref-relaxed.md
+++ b/test/fixtures/link-ref-relaxed.md
@@ -1,0 +1,2 @@
+Some paragraph text here with a [linkref]
+[linkref]: /actual/link/here

--- a/test/fixtures/link-ref.md
+++ b/test/fixtures/link-ref.md
@@ -1,0 +1,3 @@
+Some paragraph text here with a [linkref]
+
+[linkref]: /actual/link/here

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -85,6 +85,16 @@ describe('markdown processing and syntax highlighting', function () {
     assert(~indentHtml.indexOf('&#xA0;'))
   })
 
+  it('renders relaxed link reference definitions the same as normal ones', function () {
+    assert(~fixtures['link-ref'].indexOf('[linkref]:'))
+    assert(~fixtures['link-ref-relaxed'].indexOf('[linkref]:'))
+    var $normal = marky(fixtures['link-ref'])
+    var $relaxed = marky(fixtures['link-ref-relaxed'])
+    assert($normal('a[href="/actual/link/here"]').length)
+    assert($relaxed('a[href="/actual/link/here"]').length)
+    assert.equal($normal.html(), $relaxed.html())
+  })
+
   it('does not convert text emoticons to unicode', function () {
     assert(~fixtures.github.indexOf(':)'))
     var $ = marky(fixtures.github)


### PR DESCRIPTION
Here's one way to handle #159.

It's a little bit hacky. I wrote up why in a comment in `lib/relaxed-link-reference.js`, but the short version is, there were a few ways to do this, none of which is really clean:

1. Re-wire markdown-it's internal parsing rules such that [link reference definitions](http://spec.commonmark.org/0.24/#link-reference-definitions) be allowed to interrupt paragraphs (which is explicitly disallowed by the specification, but which GitHub allows). The fragility here is that this requires using a few unofficial/internal APIs, so there's no guarantee it'll continue to work as-is down the road.
1. Add our own "new" parsing rule via public API. The rule would be basically a copy/paste of markdown-it's existing [reference](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_block/reference.js) rule, but with the appropriate metadata added in order to make the rule work the way we want it. The fragility here is that we'd essentially be forking the rule, so we wouldn't pick up changes to that file in markdown-it.
1. Add our own "new" parsing rule via public API by directly doing `require('markdown-it/lib/rules_block/reference')` to pick up the function we need. This is roughly the same as the prior point, but it makes it easier to track changes to that module as markdown-it changes by shifting the fragility to creating a dependency on markdown-it's filesystem layout.

I ended up going with option 1 here because it was the smallest amount of code on our end (the implementation is literally four lines of code). However, I'm completely open to making different philosophical choices here if anyone has a strong preference.