### PR TITLE
Definition list support

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -5,7 +5,7 @@ var sanitizer = module.exports = function (html) {
 
 sanitizer.config = {
   allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-    'del', 'div', 'h1', 'h2', 'iframe', 'img', 'input', 'ins', 'meta', 'pre', 's', 'span', 'sub', 'sup'
+    'dd', 'del', 'div', 'dl', 'dt', 'h1', 'h2', 'iframe', 'img', 'input', 'ins', 'meta', 'pre', 's', 'span', 'sub', 'sup'
   ]),
   allowedClasses: {
     div: [

--- a/test/fixtures/dirty.md
+++ b/test/fixtures/dirty.md
@@ -33,3 +33,11 @@ some<sup>superscript</sup>
 <del>deleted</del>
 
 <ins>inserted</ins>
+
+<dl>
+  <dt>Term 1</dt>
+  <dd>Definition 1</dd>
+
+  <dt>Term 2</dt>
+  <dd>Definition 2</dd>
+</dl>

--- a/test/sanitize.js
+++ b/test/sanitize.js
@@ -84,4 +84,18 @@ describe('sanitize', function () {
     assert(~fixtures.dirty.indexOf('<sup>'))
     assert.equal($('sup').text(), 'superscript')
   })
+
+  it('allows the <dl> element', function () {
+    assert(~fixtures.dirty.indexOf('<dl>'))
+  })
+
+  it('allows the <dt> element', function () {
+    assert(~fixtures.dirty.indexOf('<dt>'))
+    assert.equal($('dt').eq(0).text(), 'Term 1')
+  })
+
+  it('allows the <dd> element', function () {
+    assert(~fixtures.dirty.indexOf('<dd>'))
+    assert.equal($('dd').eq(0).text(), 'Definition 1')
+  })
 })


### PR DESCRIPTION
Fixes the titular part of #169 by allowing `<dl>`, `<dt>`, and `<dd>` to pass through the sanitizer.

It's just the [one commit, 8806d0e](https://github.com/npm/marky-markdown/commit/8806d0e97ca9d888785999d939cc8063743c0346). For ease of sequencing, I've rebased this on top of #168; however, the more of these i do, the more confusing the change list for each PR looks. If you'd prefer me to do these a different way, I surely can. (Maybe a working branch for 8.0 would work better?)