### PR TITLE
Test leak variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "glob": "^7.0.0",
     "intercept-stdout": "^0.1.2",
-    "mocha": "^2.0.1",
+    "mocha": "^2.5.2",
     "standard": "^7.1.0",
     "standard-format": "^2.1.0"
   },

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -29,8 +29,15 @@ fixtures.dependencies.forEach(function (name) {
     cwd: modulePath
   })[0]
 
-  var readme = fs.readFileSync(path.resolve(modulePath, readmeFilename), 'utf-8')
-  fixtures[name] = readme
+  if (readmeFilename) {
+    var readme = fs.readFileSync(path.resolve(modulePath, readmeFilename), 'utf-8')
+    fixtures[name] = readme
+  }
+})
+
+// filter out any packages that didn't have a readme
+fixtures.dependencies = fixtures.dependencies.filter(function (name) {
+  return !!fixtures[name]
 })
 
 // Read in all the sample readmes saved as fixtures

--- a/test/marky.js
+++ b/test/marky.js
@@ -1,4 +1,5 @@
 /* globals describe, it */
+var oldkeys = Object.keys(global)
 
 var assert = require('assert')
 var marky = require('..')
@@ -77,5 +78,21 @@ describe('debug', function () {
     assert.equal($.html(), debug.html())
 
     unhookIntercept()
+  })
+})
+
+describe('after', function () {
+  it('does not leak', function () {
+    if ('deepStrictEqual' in assert) {
+      assert.deepStrictEqual(Object.keys(global), oldkeys)
+    } else {
+      // node <= 0.12 lacks assert.deepStrictEqual(), just compare manually
+      oldkeys.sort()
+      var currentkeys = Object.keys(global).sort()
+      assert.equal(currentkeys.length, oldkeys.length)
+      currentkeys.forEach(function (key, index) {
+        assert.equal(key, oldkeys[index])
+      })
+    }
   })
 })


### PR DESCRIPTION
This takes #181 (thanks, @aredridel!) and rebases it onto the changes from #184 because the tests don't work at all until that's merged. It also makes the [`.equal()`/`.deepStrictEqual()` change](https://github.com/npm/marky-markdown/pull/181#discussion_r64114887) I talked about.