### PR TITLE
Fix heading link generation when inline HTML links exist

### DIFF
--- a/lib/headings.js
+++ b/lib/headings.js
@@ -2,6 +2,14 @@ var cheerio = require('cheerio')
 var GithubSlugger = require('github-slugger')
 var tokenUtil = require('./token-util')
 
+function isMarkdownLink (token) {
+  return token.type === 'link_open'
+}
+
+function isHtmlLink (token) {
+  return token.type === 'html_inline' && token.content.substring(0, 3).toLowerCase() === '<a '
+}
+
 var headings = module.exports = function (md, options) {
   if (options && !options.prefixHeadingIds) {
     headings.prefix = ''
@@ -27,8 +35,7 @@ var headings = module.exports = function (md, options) {
     // Bail if heading already contains a hyperlink
     var children = tokens[idx + 1].children
     if (children && children.length) {
-      var links = children.filter(function (token) { return token.type === 'link_open' })
-      if (!links.length) {
+      if (children.filter(isMarkdownLink).length === 0) {
         // Generate an ID based on the heading's innerHTML; first, render without
         // converting gemoji strings to unicode emoji characters
         var rendered = md.renderer.renderInline(children.map(tokenUtil.unemoji), opts, env)
@@ -37,13 +44,15 @@ var headings = module.exports = function (md, options) {
             .replace(/[<>]/g, '') // In case the heading contains `<stuff>`
             .toLowerCase() // because `slug` doesn't lowercase
         )
-        tokens[idx].attrSet('id', headings.prefix + postfix)
 
-        // add the heading class, if any
+        // add some heading attributes
+        tokens[idx].attrSet('id', headings.prefix + postfix)
         tokens[idx].attrJoin('class', headings.className)
 
-        // wrap the contents in a link
-        tokenUtil.wrap(children, postfix)
+        // if the heading doesn't already contain a link, wrap the contents in one
+        if (children.filter(isHtmlLink).length === 0) {
+          tokenUtil.wrap(children, postfix)
+        }
       }
     }
 

--- a/test/fixtures/dirty.md
+++ b/test/fixtures/dirty.md
@@ -4,6 +4,10 @@
 
 ### [h3](/already/linky)
 
+### <a href="/already/inline/linky">h3</a>
+
+### Heading with embedded <a href="/internal/inline/linky">link</a>
+
 #### This is a TEST
 
 ##### h5

--- a/test/headings.js
+++ b/test/headings.js
@@ -21,9 +21,19 @@ describe('headings', function () {
     assert($("h1.deep-link a[href='#h1']").length)
   })
 
-  it("doesn't inject anchor tags into headings that already contain anchors", function () {
+  it("doesn't inject links into headings that already contain markdown links", function () {
     assert(~fixtures.dirty.indexOf('### [h3](/already/linky)'))
     assert($("h3 a[href='/already/linky']").length)
+  })
+
+  it("doesn't inject links into headings that already contain inline HTML links", function () {
+    assert(~fixtures.dirty.indexOf('### <a href="/already/inline/linky">h3</a>'))
+    assert($("h3 a[href='/already/inline/linky']").length)
+  })
+
+  it("doesn't inject links into headings that contain internal inline HTML links", function () {
+    assert(~fixtures.dirty.indexOf('### Heading with embedded <a href="/internal/inline/linky">link</a>'))
+    assert($("h3 a[href='/internal/inline/linky']").length)
   })
 
   it('applies a prefix to generated DOM ids by default', function () {


### PR DESCRIPTION
Should fix #200. We don't touch the inline HTML link, so there won't be any generated link that points to the slug generated for the heading's `id` attribute, but we won't double-wrap anymore, so that seems like a good tradeoff.