### PR TITLE
Dont require 'highlights' in browserify environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,30 @@ npm i -g marky-markdown
 marky-markdown some.md > some.html
 ```
 
+## In the Browser
+
+This module mostly works in the browser, with the exception of the `highlights` module.
+You can compile it to a standalone file using `browserify`.
+
+```shell
+git clone https://github.com/npm/marky-markdown
+browserify marky-markdown/index.js -i highlights -s markyMarkdown > marky-markdown.js
+```
+
+Here is an example using HTML5 to render text inside <marky-markdown> tags.
+
+```html
+<script src="marky-markdown.js"></script>
+
+<marky-markdown>**Here** _is_ some [Markdown](https://github.com/)</marky-markdown>
+
+<script>
+  for (el of document.getElementsByTagName('marky-markdown')) {
+    el.innerHTML = markyMarkdown(el.innerText, {highlightSyntax: false}).html()
+  }
+</script>
+```
+
 ## Tests
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ git clone https://github.com/npm/marky-markdown
 browserify marky-markdown/index.js -i highlights -s markyMarkdown > marky-markdown.js
 ```
 
-Here is an example using HTML5 to render text inside <marky-markdown> tags.
+Here is an example using HTML5 to render text inside `<marky-markdown>` tags.
 
 ```html
 <script src="marky-markdown.js"></script>

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,5 +1,4 @@
 var pickBy = require('lodash.pickby')
-var Highlights = require('highlights')
 var MD = require('markdown-it')
 var lazyHeaders = require('markdown-it-lazy-headers')
 var cleanup = require('./cleanup')
@@ -8,29 +7,32 @@ var codeWrap = require('./code-wrap')
 var expandTabs = require('markdown-it-expand-tabs')
 var githubHeadings = require('./headings')
 
-var highlighter = new Highlights()
+if (typeof process.browser === 'undefined') {
+  var Highlights = require('highlights')
+  var highlighter = new Highlights()
 
-var languages = [
-  'atom-language-nginx',
-  'atom-language-diff',
-  'language-dart',
-  'language-rust',
-  'language-erlang',
-  'language-glsl',
-  'language-haxe',
-  'language-ini',
-  'language-stylus'
-]
+  var languages = [
+    'atom-language-nginx',
+    'atom-language-diff',
+    'language-dart',
+    'language-rust',
+    'language-erlang',
+    'language-glsl',
+    'language-haxe',
+    'language-ini',
+    'language-stylus'
+  ]
 
-languages.forEach(function (language) {
-  highlighter.requireGrammarsSync({
-    modulePath: require.resolve(language + '/package.json')
+  languages.forEach(function (language) {
+    highlighter.requireGrammarsSync({
+      modulePath: require.resolve(language + '/package.json')
+    })
   })
-})
 
-// cleanup generated rules in the highlighter registry if they are idle for 2000ms
-// they take a tremendous amount of memory if you process many languages in a server type environment.
-cleanup(highlighter.registry.grammars)
+  // cleanup generated rules in the highlighter registry if they are idle for 2000ms
+  // they take a tremendous amount of memory if you process many languages in a server type environment.
+  cleanup(highlighter.registry.grammars)
+}
 
 module.exports = function (html, options) {
   var mdOptions = {


### PR DESCRIPTION
This change should make it possible to use marky-markdown with
browserify as long as the {highlightSyntax: false} option is used.
Using with {highlightSyntax: true} would generate a runtime error
in the browser.

Example command:
  browserify main.js -i highlights > bundle.js

Also note that by not including the highlights library, the file
size of the resulting bundle is reduced by half.

Would close #46