### PR TITLE
Bump highlights to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Progress toward feature parity with GitHub's markdown rendering continues...
 
 ### New Features / Breaking Changes
 
+- get your `class` on: syntax highlighting now supports ES2015 ([pull/206])!
+  The changes to the rendered markup for highlighted JavaScript
+  aren't purely additive (we wish we could be more specific, but the
+  functionality comes from [atom/language-javascript], which currently
+  doesn't publish a changelog; if you're feeling particularly brave,
+  there's always the [diff](https://github.com/atom/language-javascript/compare/b47a7fe...5fb7053)
+  :flushed:), so dependening on how your CSS works, there may or may
+  not be non-trivial work for you to do
 - changed the way certain links are auto-generated (i.e., linkifying
   `www.example.com` but not `readme.md`) so as to more closely match
   how Github does it ([pull/151], [issue/146]); thanks to [puzrin]
@@ -14,7 +22,7 @@ Progress toward feature parity with GitHub's markdown rendering continues...
 - we now allow [link reference definitions] to appear immediately
   following paragraphs rather than requiring a blank link in between
   them; this contradicts
-  [CommonMark](http://spec.commonmark.org/0.24/#example-172) but
+  [CommonMark](http://spec.commonmark.org/0.25/#example-175) but
   matches Github's behavior. ([issue/159], [pull/164])
 - we now support Github flavored markdown [task lists] in markdown
   documents. ([issue/166], [pull/168])
@@ -61,6 +69,8 @@ Due to the update to `markdown-it` (see below), our markdown parsing now uses Co
 
   - valid link schemes used to be enumerated ('http', 'https', 'ftp', etc...); now they're defined as "any sequence	of 2--32 characters beginning with an ASCII letter and followed by any combination of ASCII letters, digits, or the symbols plus ('+'), period ('.'), or hyphen ('-')"; in practice, this won't affect most documents, but it *is* more flexible and future-compatible.
 
+[pull/206]: https://github.com/npm/marky-markdown/pull/206
+[atom/language-javascript]: https://github.com/atom/language-javascript/tree/5fb7053b459ba595459f93fea10f5341cd3cc206
 [pull/151]: https://github.com/npm/marky-markdown/pull/151
 [issue/146]: https://github.com/npm/marky-markdown/issues/146
 [puzrin]: https://github.com/puzrin

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cheerio": "^0.20.0",
     "github-slugger": "^1.0.0",
     "github-url-to-object": "^2.2.3",
-    "highlights": "^1.3.0",
+    "highlights": "^1.4.0",
     "highlights-tokens": "^1.0.1",
     "language-dart": "^0.1.1",
     "language-erlang": "^2.0.0",

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -118,7 +118,7 @@ describe('markdown processing', function () {
     })
 
     it('applies inline syntax highlighting classes to javascript', function () {
-      assert($('.js.modifier').length)
+      assert($('.js.punctuation').length)
       assert($('.js.function').length)
     })
 


### PR DESCRIPTION
This ends up changing how syntax highlighted JS code renders, so it requires a test update.

**Note** that as of this writing, `highlights@1.4.0` isn't actually out yet, just `1.4.0-candidate`, for testing purposes. Once the final one is published, we can merge this.