### PR TITLE
Allow `align` attribute on `<p>` elements

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -50,6 +50,7 @@ sanitizer.config = {
     h6: ['id'],
     a: ['href', 'id', 'name', 'target', 'title'],
     img: ['id', 'src', 'width', 'height', 'valign', 'title'],
+    p: ['align'],
     meta: ['name', 'content'],
     iframe: ['src', 'frameborder', 'allowfullscreen'],
     input: ['checked', 'class', 'disabled', 'type'],

--- a/test/fixtures/dirty.md
+++ b/test/fixtures/dirty.md
@@ -42,6 +42,8 @@ some<sup>superscript</sup>
   <dd>Definition 2</dd>
 </dl>
 
+<p align='center'>Centered paragraph</p>
+
 
 | First | Second | Third |
 |---:|:--:|:---|

--- a/test/sanitize.js
+++ b/test/sanitize.js
@@ -99,6 +99,11 @@ describe('sanitize', function () {
     assert.equal($('dd').eq(0).text(), 'Definition 1')
   })
 
+  it('allows <p> alignment', function () {
+    assert(~fixtures.dirty.indexOf('<p align='))
+    assert($('p[align]').length > 0)
+  })
+
   it('allows table cell left alignment', function () {
     var html = marky(fixtures.dirty).html()
     assert(html.indexOf('<th style="text-align:left">') > -1)


### PR DESCRIPTION
Fixes #241 by allowing the `align` attribute on `<p>` elements to make it through the sanitizer.