### PR TITLE
Replace cheerio-based heading ID processing with custom string processor

### DIFF
--- a/lib/heading-links.js
+++ b/lib/heading-links.js
@@ -1,5 +1,5 @@
-var cheerio = require('cheerio')
 var GithubSlugger = require('github-slugger')
+var innertext = require('innertext')
 var tokenUtil = require('./token-util')
 
 // shamelessly borrowed from GitHub, thanks y'all
@@ -33,7 +33,7 @@ var headings = module.exports = function (md, options) {
       // converting gemoji strings to unicode emoji characters
       var rendered = md.renderer.renderInline(children.map(tokenUtil.unemoji), opts, env)
       var postfix = slugger.slug(
-        cheerio.load(rendered).root().text()
+        innertext(rendered)
           .replace(/[<>]/g, '') // In case the heading contains `<stuff>`
           .toLowerCase() // because `slug` doesn't lowercase
       )

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "github-url-to-object": "^2.2.3",
     "highlights": "^1.4.1",
     "highlights-tokens": "^1.0.1",
+    "innertext": "^1.0.1",
     "language-dart": "^0.1.1",
     "language-erlang": "^2.0.0",
     "language-glsl": "^2.0.1",


### PR DESCRIPTION
Hey @ashleygwilliams please look this over first, but I think this works for taking cheerio out of the process by which we generate heading link IDs.

I have a local cache of the entire npm package repository's README files that I pulled a few days ago using a modified readme-tester, and I ran marky against the first 100,000 files (which come in sorted alphabetically by package name). The difference before/after this change is small, but it looks like 0.5–1ms per readme on average, so it's something. It's not remotely enough for #149 to be done, but it's a step in the right direction. I think?