### PR TITLE
Allow `align` attribute on `<img>` elements

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -51,7 +51,7 @@ sanitizer.config = {
     h5: ['id'],
     h6: ['id'],
     a: ['href', 'id', 'name', 'target', 'title'],
-    img: ['id', 'src', 'width', 'height', 'valign', 'title'],
+    img: ['id', 'src', 'width', 'height', 'align', 'valign', 'title'],
     p: ['align'],
     meta: ['name', 'content'],
     iframe: ['src', 'frameborder', 'allowfullscreen'],

--- a/test/fixtures/dirty.md
+++ b/test/fixtures/dirty.md
@@ -26,7 +26,7 @@
 
 <script charset="utf-8" src="http://malware.com" type="text/javascript">alert("haxorz")</script>
 
-<img src="local.png" width="600" height="400" valign="middle" onclick="maliciousClickHandler()"></img>
+<img src="local.png" width="600" height="400" align="right" valign="middle" onclick="maliciousClickHandler()"></img>
 
 <a class="xxx" href="http://yyy.com">zzz</a>
 

--- a/test/sanitize.js
+++ b/test/sanitize.js
@@ -29,6 +29,7 @@ describe('sanitize', function () {
     assert($('img').length)
     assert.equal($('img').attr('width'), '600')
     assert.equal($('img').attr('height'), '400')
+    assert.equal($('img').attr('align'), 'right')
     assert.equal($('img').attr('valign'), 'middle')
     assert.equal($('img').attr('onclick'), undefined)
   })


### PR DESCRIPTION
Fixes #269. I'll do this in #251 as well, in which case this one will become redundant (but it's here in case we don't merge it for 9.0 for any reason)