### PR TITLE
Update bin/marky-markdown to simply output the html string returned from marky.

### DIFF
--- a/bin/marky-markdown.js
+++ b/bin/marky-markdown.js
@@ -12,6 +12,6 @@ var filePath = path.resolve(process.cwd(), process.argv[2])
 
 fs.readFile(filePath, function (err, data) {
   if (err) throw err
-  var $ = marky(data.toString())
-  process.stdout.write($.html())
+  var html = marky(data.toString())
+  process.stdout.write(html)
 })


### PR DESCRIPTION
Cheerio object is no longer returned from marky as referenced in this commit:
https://github.com/npm/marky-markdown/commit/30865e4c37fae402d9e18b83a669bf8103259d27#diff-168726dbe96b3ce427e7fedce31bb0bcR40

I was getting the following error running the bin/marky-markdown script from the repo:

> /Users/sjking/repos/marky-markdown/bin/marky-markdown.js:16
>   process.stdout.write($.html())
>                          ^
> 
> TypeError: $.html is not a function
>   at /Users/sjking/repos/marky-markdown/bin/marky-markdown.js:16:26
>   at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:445:3)