### PR TITLE
Add new getParser public API

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,17 @@ var defaults = require('lodash.defaults')
 var render = require('./lib/render')
 var sanitize = require('./lib/sanitize')
 
+var defaultOptions = {
+  sanitize: true,
+  linkify: true,
+  highlightSyntax: true,
+  prefixHeadingIds: true,
+  enableHeadingLinkIcons: true,
+  serveImagesWithCDN: false,
+  debug: false,
+  package: null
+}
+
 var marky = module.exports = function (markdown, options) {
   var html
 
@@ -10,16 +21,7 @@ var marky = module.exports = function (markdown, options) {
   }
 
   options = options || {}
-  defaults(options, {
-    sanitize: true,
-    linkify: true,
-    highlightSyntax: true,
-    prefixHeadingIds: true,
-    enableHeadingLinkIcons: true,
-    serveImagesWithCDN: false,
-    debug: false,
-    package: null
-  })
+  defaults(options, defaultOptions)
 
   var log = function (msg) {
     if (options.debug) {
@@ -42,4 +44,8 @@ var marky = module.exports = function (markdown, options) {
 
 marky.parsePackageDescription = function (description) {
   return sanitize(render.renderPackageDescription(description))
+}
+
+marky.getParser = function (options) {
+  return render.getParser(defaults(options || {}, defaultOptions))
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -46,7 +46,11 @@ if (typeof process.browser === 'undefined') {
   cleanup(highlighter.registry.grammars)
 }
 
-var render = module.exports = function (html, options) {
+var render = module.exports = function (markdown, options) {
+  return render.getParser(options).render(markdown)
+}
+
+render.getParser = function (options) {
   var mdOptions = {
     html: true,
     langPrefix: 'highlight ',
@@ -79,7 +83,11 @@ var render = module.exports = function (html, options) {
   if (options.highlightSyntax) parser.use(codeWrap)
   if (options.serveImagesWithCDN) parser.use(cdnImages, {package: options.package})
 
-  return githubLinkify(parser).render(html)
+  return githubLinkify(parser)
+}
+
+render.renderPackageDescription = function (description) {
+  return MD({html: true}).renderInline(description)
 }
 
 var mappings = {
@@ -107,8 +115,4 @@ function scopeNameFromLang (highlighter, lang) {
   // mappings[lang] = name
 
   return name
-}
-
-render.renderPackageDescription = function (description) {
-  return MD({html: true}).renderInline(description)
 }


### PR DESCRIPTION
Here's a speculative change that adds a new public API:

### getParser([options])

Returns a marky-markdown-flavored markdown-it parser object. You can attach other markdown-it plugins, inspect the internals for debugging, etc... For example:

```js
var marky = require('marky-markdown')
var someMarkdownItPlugin = require('some-fake-markdown-it-plugin')

var parser = marky.getParser({ package: somePackage, highlightSyntax: false })

parser.use(someMarkdownItPlugin)

var html = parser.render(html)
```

`marky.getParser(options).render(markdown)` is the exact same thing as the existing `marky.render(markdown, options)`