### PR TITLE
Add tests and documentation for getParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ The default options are as follows:
 }
 ```
 
+### Low Level Parser Access
+
+If you need lower level access to the markdown-it parser (to add your own
+[markdown-it plugins](https://www.npmjs.com/search?q=markdown-it-plugin), for
+example), you can call the `getParser` method:
+
+```js
+var parser = marky.getParser()
+parser.use(someMarkdownItPlugin)
+var html = parser.render("# markdown string")
+```
+
+`getParser` takes an optional `options` argument, the same format as the main
+marky-markdown export function. If you omit it, it uses the same default options
+described above.
+
+When you're done customizing the parser, call `parser.render(markdown)` to
+render to HTML.
+
 ## Command-line Usage
 
 You can use marky-markdown to parse markdown files in the shell.

--- a/index.js
+++ b/index.js
@@ -47,5 +47,15 @@ marky.parsePackageDescription = function (description) {
 }
 
 marky.getParser = function (options) {
-  return render.getParser(defaults(options || {}, defaultOptions))
+  options = options || {}
+
+  var parser = render.getParser(defaults(options, defaultOptions))
+
+  if (options.sanitize) {
+    var originalRender = parser.render
+    parser.render = function (markdown) {
+      return sanitize(originalRender.call(parser, markdown))
+    }
+  }
+  return parser
 }

--- a/test/marky.js
+++ b/test/marky.js
@@ -5,7 +5,7 @@ var assert = require('assert')
 var marky = require('..')
 var fixtures = require('./fixtures')
 var intercept = require('intercept-stdout')
-var cheerio = require('cheerio')
+var markdownIt = require('markdown-it')
 
 describe('marky-markdown', function () {
   it('is a function', function () {
@@ -13,12 +13,9 @@ describe('marky-markdown', function () {
     assert(typeof marky === 'function')
   })
 
-  it('accepts a markdown string and returns a cheerio DOM object', function () {
-    var $ = cheerio.load(marky('hello, world'))
-    assert($.html)
-    assert($._root)
-    assert($._options)
-    assert(~$.html().indexOf('<p>hello, world</p>\n'))
+  it('accepts a markdown string and returns an HTML string', function () {
+    var html = marky('hello, world')
+    assert(~html.toLowerCase().indexOf('<p>hello, world</p>\n'))
   })
 
   it('throws an error if first argument is not a string', function () {
@@ -26,6 +23,26 @@ describe('marky-markdown', function () {
       function () { marky(null) },
       /first argument must be a string/
     )
+  })
+
+  it('has a getParser method', function () {
+    assert(typeof marky.getParser === 'function')
+  })
+
+  it('getParser returns a markdown-it parser', function () {
+    assert(marky.getParser() instanceof markdownIt)
+  })
+
+  it('getParser.render returns the same as marky.render (sanitize: true)', function () {
+    var html = marky(fixtures.benchmark)
+    var parserHtml = marky.getParser().render(fixtures.benchmark)
+    assert.equal(html, parserHtml)
+  })
+
+  it('getParser.render returns the same as marky.render (sanitize: false)', function () {
+    var html = marky(fixtures.benchmark, {sanitize: false})
+    var parserHtml = marky.getParser({sanitize: false}).render(fixtures.benchmark)
+    assert.equal(html, parserHtml)
   })
 })
 


### PR DESCRIPTION
Here are docs and tests for #286. This also updates the parser object returned by `getParser` such that it will sanitize the generated HTML when `{sanitize: true}` is passed (or not specified; it's the default).