### PR TITLE
use `anchor` as class name instead of `deep-link`

### DIFF
--- a/lib/plugin/heading-links.js
+++ b/lib/plugin/heading-links.js
@@ -62,4 +62,4 @@ var headings = module.exports = function (md, options) {
 }
 
 headings.defaultPrefix = 'user-content-'
-headings.className = 'deep-link'
+headings.className = 'anchor'

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -8,7 +8,7 @@ sanitizer.config = {
     'dd', 'del', 'div', 'dl', 'dt', 'h1', 'h2', 'iframe', 'img', 'input', 'ins', 'meta', 'path', 'pre', 's', 'span', 'sub', 'sup', 'svg'
   ]),
   allowedClasses: {
-    a: ['deep-link'],
+    a: ['anchor'],
     div: [
       'highlight',
       'hljs',
@@ -30,7 +30,7 @@ sanitizer.config = {
       'xml',
       'youtube-video'
     ],
-    h1: ['deep-link', 'package-name-redundant', 'package-description-redundant'],
+    h1: ['anchor', 'package-name-redundant', 'package-description-redundant'],
     h2: ['deep-link'],
     h3: ['deep-link'],
     h4: ['deep-link'],

--- a/test/headings.js
+++ b/test/headings.js
@@ -27,9 +27,9 @@ describe('headings', function () {
     assert($("h1 a[href='#h1']").length)
   })
 
-  it('adds deep-link class to added heading links', function () {
+  it('adds anchor class to added heading links', function () {
     assert(~fixtures.dirty.indexOf('# h1'))
-    assert($("h1 a.deep-link[href='#h1']").length)
+    assert($("h1 a.anchor[href='#h1']").length)
   })
 
   it("doesn't inject links into headings that already contain markdown links", function () {

--- a/test/headings.js
+++ b/test/headings.js
@@ -59,12 +59,12 @@ describe('headings', function () {
   })
 
   it('puts icons inside the generated heading links', function () {
-    assert(!!$('a.deep-link svg').length)
+    assert(!!$('a.anchor svg').length)
   })
 
   it("allows generated links' icons to be disabled", function () {
     $ = cheerio.load(marky(fixtures.dirty, {enableHeadingLinkIcons: false}))
-    assert.equal($('a.deep-link svg').length, 0)
+    assert.equal($('a.anchor svg').length, 0)
   })
 
   it('allows a dash in generated DOM ids just like GitHub', function () {

--- a/test/htmlheading.js
+++ b/test/htmlheading.js
@@ -72,12 +72,12 @@ describe('html-headings', function () {
     })
 
     it('puts icons inside the generated heading links', function () {
-      assert(!!$('a.deep-link svg').length)
+      assert(!!$('a.anchor svg').length)
     })
 
     it("allows generated links' icons to be disabled", function () {
       $ = cheerio.load(marky(fixtures.htmlheading, {enableHeadingLinkIcons: false}))
-      assert.equal($('a.deep-link svg').length, 0)
+      assert.equal($('a.anchor svg').length, 0)
     })
   })
 })

--- a/test/htmlheading.js
+++ b/test/htmlheading.js
@@ -40,9 +40,9 @@ describe('html-headings', function () {
       assert($("h1 a[href='#one-space']").length)
     })
 
-    it('adds deep-link class to added heading links', function () {
+    it('adds anchor class to added heading links', function () {
       assert(~fixtures.htmlheading.indexOf('<h1>one space</h1>'))
-      assert($("h1 a.deep-link[href='#one-space']").length)
+      assert($("h1 a.anchor[href='#one-space']").length)
     })
 
     it("doesn't inject links into headings that already contain markdown links", function () {


### PR DESCRIPTION
fixes #288 