### PR TITLE
Add html_block github image/link replacer

### DIFF
--- a/lib/plugin/github.js
+++ b/lib/plugin/github.js
@@ -18,7 +18,7 @@ function buildLinkUrl (repository, url) {
 // using the repository object provided
 function replaceTagAttribute (html, tag, attribute, buildUrl, repository) {
   // look for the attribute's value
-  var regex = new RegExp('^<\\s*' + tag + '[^>]*\\b' + attribute + '\\s*=\\s*', 'i')
+  var regex = new RegExp('<\\s*' + tag + '[^>]*\\b' + attribute + '\\s*=\\s*', 'i')
   var attr = html.match(regex)
   if (attr) {
     // mark the location and figure out what kind of quotation mark is delimiting the value
@@ -87,15 +87,19 @@ module.exports = function (md, opts) {
     }
   }
 
-  // rewrite image locations in inline HTML to be fully qualified github URLs
-  var originalHtmlInlineRule = md.renderer.rules.html_inline
-  md.renderer.rules.html_inline = function (tokens, idx, options, env, self) {
-    var content = tokens[idx].content
-    var imgHtml = replaceTagAttribute(content, 'img', 'src', buildImageUrl, repo)
-    var linkHtml = replaceTagAttribute(content, 'a', 'href', buildLinkUrl, repo)
+  function makeHtmlTransformer (originalRule) {
+    return function (tokens, idx, options, env, self) {
+      var content = tokens[idx].content
+      var imgHtml = replaceTagAttribute(content, 'img', 'src', buildImageUrl, repo)
+      var linkHtml = replaceTagAttribute(content, 'a', 'href', buildLinkUrl, repo)
 
-    tokens[idx].content = imgHtml || linkHtml || content
+      tokens[idx].content = imgHtml || linkHtml || content
 
-    return originalHtmlInlineRule.call(this, tokens, idx, options, env, self)
+      return originalRule.call(this, tokens, idx, options, env, self)
+    }
   }
+
+  // rewrite image locations in inline/block HTML as fully qualified github URLs
+  md.renderer.rules.html_inline = makeHtmlTransformer(md.renderer.rules.html_inline)
+  md.renderer.rules.html_block = makeHtmlTransformer(md.renderer.rules.html_block)
 }

--- a/test/fixtures/github.md
+++ b/test/fixtures/github.md
@@ -54,3 +54,7 @@ Smiley! :)
 
 # Heading with nested image/link: <a href="nested/link/image"><img src="nested/link/image/image.png"></a>. Nice.
 
+<img src="html/block.png" />
+
+<p><a href="html/block.html">Link in an HTML block</a></p>
+

--- a/test/repo-github.js
+++ b/test/repo-github.js
@@ -38,7 +38,9 @@ describe('when package repo is on github', function () {
 
   it('rewrites slashy relative links hrefs to absolute (HTML)', function () {
     assert(~fixtures.github.indexOf('<a href="nested/link/image">'))
+    assert(~fixtures.github.indexOf('<a href="html/block.html">Link in an HTML block</a>'))
     assert($("a[href='https://github.com/mark/wahlberg/blob/master/nested/link/image']").length)
+    assert($("a[href='https://github.com/mark/wahlberg/blob/master/html/block.html']").length)
   })
 
   it('leaves protocol-relative URLs alone', function () {
@@ -70,7 +72,9 @@ describe('when package repo is on github', function () {
 
   it('replaces slashy relative img URLs with github URLs (HTML)', function () {
     assert(~fixtures.github.indexOf('<img src="nested/link/image/image.png">'))
+    assert(~fixtures.github.indexOf('<img src="html/block.png" />'))
     assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/master/nested/link/image/image.png']").length)
+    assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/master/html/block.png']").length)
   })
 
   it('leaves protocol relative URLs alone', function () {


### PR DESCRIPTION
Fixes #320 by also scanning `html_block` tokens for links & images to rewrite with GitHub URLs