### PR TITLE
Non Greedy HTML Block Parsing

### DIFF
--- a/lib/gfm/abstemious-html-block.js
+++ b/lib/gfm/abstemious-html-block.js
@@ -1,0 +1,90 @@
+module.exports = function (md, options) {
+  // Unfortunately, there's no public API for getting access to the existing
+  // installed parsing rules; rather than import the 'html_block' rule directly
+  // from markdown-it just so we can wrap it with our custom logic here, we just
+  // use internal utility methods to modify it in place at runtime.
+  //
+  // Normally, CommonMark HTML blocks are terminated by a blank line. However,
+  // GitHub will terminate blocks early if the parser encounters Markdown in
+  // subsequent lines even before it reaches a blank one. To match that
+  // behavior, what we do here is:
+  //
+  //   1 Run the html_block rule to see if the current line is the start of an
+  //     HTML block
+  //
+  //   2 If so, walk through the block line by line, running each line through
+  //     each of the higher priority block rules (in validation mode, since
+  //     we're only testing for matches) until we find either a blank line or a
+  //     line that validates as one of those rules (e.g., a list, heading, etc...)
+  //
+  //   3 If we found a blank line or a markdown line, update the bounds and
+  //     content of the html_block that was created in step 1 and reset
+  //     state.line such that markdown-it will resume parsing from that point
+  //
+  // That means that this (among other things) works:
+  //
+  //   <img src="some/image.png"/>
+  //   - the start of a list
+  //   - the second item
+  //   - etc
+  //
+  // ...whereas spec compliance requires a blank line between the two, because
+  // CommonMark considers the entire thing to be a single HTML block.
+
+  var ruler = md.block.ruler
+  var ruleList = ruler.__rules__
+  var originalEntry = ruleList[ruleIndex(ruler, 'html_block')]
+  var originalRule = originalEntry.fn
+
+  ruler.at('html_block', abstemiousHtmlBlock, {alt: originalEntry.alt})
+
+  function abstemiousHtmlBlock (state, startLine, endLine, silent) {
+    if (!originalRule.apply(this, arguments)) { return false }
+
+    // got an HTML block; fetch the higher precedence block rules
+    var rules = ruleList.filter(isHigherPriorityRule(ruleIndex(ruler, 'html_block')))
+    var context = this
+
+    // walk through each line in the block looking for anything that works
+    // as block type markdown
+    for (var nextLine = startLine + 1; nextLine < endLine; nextLine++) {
+      var start = state.bMarks[nextLine] + state.tShift[nextLine]
+      var isBlank = start === state.eMarks[nextLine]
+      var matched = rules.some(function (rule) { return ruleMatches(rule, state, nextLine, endLine, context) })
+
+      if (isBlank || matched) {
+        if (!silent) { updateParserState(state, startLine, nextLine) }
+        break
+      }
+    }
+    return true
+  }
+
+  function ruleIndex (rulerObject, ruleName) {
+    return rulerObject.__find__(ruleName)
+  }
+
+  function isHigherPriorityRule (ruleIndex) {
+    return function (rule, index) {
+      // 'code' is a special case here; we exclude it from being able to break
+      // up an HTML block without a blank line in between. If we left it in the
+      // list of rules to check, then deeply nested markup (e.g., tables, div
+      // inception, etc.) would be incorrectly turned into code blocks
+      return rule.enabled && index < ruleIndex && rule.name !== 'code'
+    }
+  }
+
+  function ruleMatches (rule, state, nextLine, endLine, context) {
+    // run the rule in silent/validation mode to see if it matches
+    return rule.fn.call(context, state, nextLine, endLine, true)
+  }
+
+  function updateParserState (state, startLine, endLine) {
+    // rewrite the html_block token to stop on `endLine` and reset the parser
+    // state so the next rule will resume at that line
+    var token = state.tokens[state.tokens.length - 1]
+    token.map = [startLine, endLine]
+    token.content = state.getLines(startLine, endLine, state.blkIndent, true)
+    state.line = endLine
+  }
+}

--- a/lib/render.js
+++ b/lib/render.js
@@ -19,6 +19,7 @@ var htmlHeading = require('./plugin/html-heading')
 var relaxedLinkRefs = require('./gfm/relaxed-link-reference')
 var githubHeadings = require('./gfm/indented-headings')
 var overrideLinkDestinationParser = require('./gfm/override-link-destination-parser')
+var abstemiousHtmlBlocks = require('./gfm/abstemious-html-block')
 
 if (typeof process.browser === 'undefined') {
   var Highlights = require('highlights')
@@ -81,6 +82,7 @@ render.getParser = function (options) {
     .use(packagize, {package: options.package})
     .use(htmlHeading)
     .use(overrideLinkDestinationParser)
+    .use(abstemiousHtmlBlocks)
 
   if (options.highlightSyntax) parser.use(codeWrap)
   if (options.serveImagesWithCDN) parser.use(cdnImages, {package: options.package})

--- a/test/fixtures/abstemious-html-block.md
+++ b/test/fixtures/abstemious-html-block.md
@@ -1,0 +1,26 @@
+<img src="path/to/image.png" />
+- item 1
+- item 2
+- item 3
+
+<img src="path/to/image.png" />
+> blockquote here
+> second blockquote line
+
+<img src="path/to/image.png" />
+# heading
+
+<img src="path/to/image.png" />
+lheading
+--------
+
+<img src="path/to/image.png" />
+```js
+  fencedCode()
+```
+
+<img src="path/to/image.png" />
+| Col1 | Col2 | Col3 |
+|---:|:--:|:---|
+| Item 1 | Item 2 | Item 3 |
+

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -288,4 +288,35 @@ describe('markdown processing', function () {
       assert($("a[href='http://www.example.name/marky?markdown=1&test']").length)
     })
   })
+
+  describe('markdown after HTML blocks without an intervening blank line', function () {
+    var $
+    before(function () {
+      $ = cheerio.load(marky(fixtures['abstemious-html-block']))
+    })
+
+    it('processes a list', function () {
+      assert.equal($('ul').length, 1)
+    })
+
+    it('processes a blockquote', function () {
+      assert.equal($('blockquote').length, 1)
+    })
+
+    it('processes a #-style heading', function () {
+      assert.equal($('h1').length, 1)
+    })
+
+    it('processes a --- style heading', function () {
+      assert.equal($('h2').length, 1)
+    })
+
+    it('processes a code fence', function () {
+      assert.equal($('div.highlight.js').length, 1)
+    })
+
+    it('processes a table', function () {
+      assert.equal($('table').length, 1)
+    })
+  })
 })


### PR DESCRIPTION
Here's a markdown-it plugin and tests to cover what's in #317, where we have markdown appearing after an HTML block without the CommonMark-mandated blank line in between.

This is fairly tricky, because the reasoning behind CommonMark's behavior here is completely sensible: once an HTML block is started, how can we tell it's actually finished? What this PR does is check to see if the lines in the parsed HTML block match any of the higher priority "block" type markdown parsing rules (list, heading, etc...), and if so, adjusts the parsing state to cut the HTML block off at the first sight of valid markdown.

Note that this only works its magic on "block" type rules. Before this PR, the following gets parsed as one big `html_block` token:
```markdown
<img src="path/to/image.png"/>
- item 1
- item 2
```
and now that's an `html_block` followed by an unordered list. However:
```markdown
<img src="path/to/image.png"/>
some +other+ **formatted* _text_
```
will still be a single `html_block`.

Fixes #317