### PR TITLE
Allow headings to interrupt paragraphs.

### DIFF
--- a/lib/gfm/indented-headings.js
+++ b/lib/gfm/indented-headings.js
@@ -18,9 +18,12 @@ module.exports = function (md, options) {
   // ... whereas on GitHub, those become standard paragraphs.
 
   var ruler = md.block.ruler
-  var originalRule = ruler.__rules__[ruler.__find__('heading')].fn
+  var originalEntry = ruler.__rules__[ruler.__find__('heading')]
+  var originalRule = originalEntry.fn
 
-  ruler.at('heading', function (state, startLine, endLine, silent) {
+  ruler.at('heading', noIndentedHeadings, {alt: originalEntry.alt})
+
+  function noIndentedHeadings (state, startLine, endLine, silent) {
     // conveniently, state.tShift holds a count of the number of leading spaces
     // on each line, so all we need to do is return false if it's non-zero
     if (state.tShift[startLine] > 0) {
@@ -28,5 +31,5 @@ module.exports = function (md, options) {
     } else {
       return originalRule.apply(this, arguments)
     }
-  })
+  }
 }

--- a/test/headings.js
+++ b/test/headings.js
@@ -202,4 +202,10 @@ describe('headings', function () {
     assert.equal($('h5 a#lazy-heading-5').length, 1)
     assert.equal($('h6 a#lazy-heading-6').length, 1)
   })
+
+  it('allows headings to interrupt paragraphs', function () {
+    var markdown = 'this is a paragraph\n# Heading text\nSome more text here\nand another line'
+    $ = cheerio.load(marky(markdown, {prefixHeadingIds: false}))
+    assert.equal($('h1').length, 1)
+  })
 })


### PR DESCRIPTION
This fixes a bug in the indented-headings plugin where we were dropping the parsing rule's `alt` value, which is what tells markdown-it which rules can interrupt which other rules without requiring a terminating blank line.

Fixes #324