### PR TITLE
Skip syntax highlighting on code fences having no language specified

### DIFF
--- a/lib/plugin/code-wrap.js
+++ b/lib/plugin/code-wrap.js
@@ -25,7 +25,11 @@ var plugin = module.exports = function (md, options) {
       attrs: attributes
     }
 
-    return '<' + plugin.tag + slf.renderAttrs(fakeToken) + '>' + output + '</' + plugin.tag + '>\n'
+    if (!langName) {
+      return output
+    } else {
+      return '<' + plugin.tag + slf.renderAttrs(fakeToken) + '>' + output + '</' + plugin.tag + '>\n'
+    }
   }
 }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -60,6 +60,7 @@ render.getParser = function (options) {
 
   if (options.highlightSyntax) {
     mdOptions.highlight = function (code, lang) {
+      if (!lang) { return '' }
       return highlighter.highlightSync({
         fileContents: code,
         scopeName: scopeNameFromLang(highlighter, lang)

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -149,6 +149,10 @@ describe('markdown processing', function () {
       assert.equal($('div.highlight').length, $('div.highlight > pre.editor').length)
     })
 
+    it('skips code highlighter wrapper when no language is specified', function () {
+      assert(!~marky('```\nsomething()\n```').indexOf('highlight'))
+    })
+
     it('applies inline syntax highlighting classes to javascript', function () {
       assert($('.js.punctuation').length)
       assert($('.js.function').length)


### PR DESCRIPTION
This gets us closer to github rendering by omitting the wrapping `<div>` and skipping the syntax highlighter on code fences that don't have a language provided, e.g.,
````
```
something()
```
````

Fixes #318