### PR TITLE
Allow whitespace between image/link labels and paths

### DIFF
--- a/lib/gfm/image.js
+++ b/lib/gfm/image.js
@@ -1,0 +1,179 @@
+// CommonMark specifies that images have no whitespace between the alt text and
+// src, e.g.:
+//
+//     ![alt text](path/to/the/image)
+//
+// However, GitHub allows you to put whitespace between the `]` and `(`
+// characters, like so:
+//
+//     ![alt text]    (path/to/the/image)
+//
+// To account for the difference, we need to override markdown-it's image rule.
+// This file is a copy of the original markdown-it source, plus the necessary
+// modifications, wrapped as a markdown-it plugin.
+
+// Process ![image](<src> "title")
+
+'use strict'
+
+module.exports = function (md) {
+  md.inline.ruler.at('image', image)
+}
+
+function image (state, silent) {
+  var attrs
+  var code
+  var content
+  var label
+  var labelEnd
+  var labelStart
+  var pos
+  var ref
+  var res
+  var title
+  var token
+  var tokens
+  var start
+  var href = ''
+  var oldPos = state.pos
+  var max = state.posMax
+  var isSpace = state.md.utils.isSpace
+  var normalizeReference = state.md.utils.normalizeReference
+
+  if (state.src.charCodeAt(state.pos) !== 0x21/* ! */) { return false }
+  if (state.src.charCodeAt(state.pos + 1) !== 0x5B/* [ */) { return false }
+
+  labelStart = state.pos + 2
+  labelEnd = state.md.helpers.parseLinkLabel(state, state.pos + 1, false)
+
+  // parser failed to find ']', so it's not a valid link
+  if (labelEnd < 0) { return false }
+
+  pos = labelEnd + 1
+
+  // BEGIN CUSTOM MODIFICATION
+  // look ahead to see if the next non-whitespace character is '(', and if
+  // it is, skip the whitespace
+  for (; pos < max; pos++) {
+    code = state.src.charCodeAt(pos)
+    if (!isSpace(code) && code !== 0x0A) { break }
+  }
+  if (pos < max && state.src.charCodeAt(pos) !== 0x28) { pos = labelEnd + 1 }
+  // END CUSTOM MODIFICATION
+
+  if (pos < max && state.src.charCodeAt(pos) === 0x28/* ( */) {
+    //
+    // Inline link
+    //
+
+    // [link](  <href>  "title"  )
+    //        ^^ skipping these spaces
+    pos++
+    for (; pos < max; pos++) {
+      code = state.src.charCodeAt(pos)
+      if (!isSpace(code) && code !== 0x0A) { break }
+    }
+    if (pos >= max) { return false }
+
+    // [link](  <href>  "title"  )
+    //          ^^^^^^ parsing link destination
+    start = pos
+    res = state.md.helpers.parseLinkDestination(state.src, pos, state.posMax)
+    if (res.ok) {
+      href = state.md.normalizeLink(res.str)
+      if (state.md.validateLink(href)) {
+        pos = res.pos
+      } else {
+        href = ''
+      }
+    }
+
+    // [link](  <href>  "title"  )
+    //                ^^ skipping these spaces
+    start = pos
+    for (; pos < max; pos++) {
+      code = state.src.charCodeAt(pos)
+      if (!isSpace(code) && code !== 0x0A) { break }
+    }
+
+    // [link](  <href>  "title"  )
+    //                  ^^^^^^^ parsing link title
+    res = state.md.helpers.parseLinkTitle(state.src, pos, state.posMax)
+    if (pos < max && start !== pos && res.ok) {
+      title = res.str
+      pos = res.pos
+
+      // [link](  <href>  "title"  )
+      //                         ^^ skipping these spaces
+      for (; pos < max; pos++) {
+        code = state.src.charCodeAt(pos)
+        if (!isSpace(code) && code !== 0x0A) { break }
+      }
+    } else {
+      title = ''
+    }
+
+    if (pos >= max || state.src.charCodeAt(pos) !== 0x29/* ) */) {
+      state.pos = oldPos
+      return false
+    }
+    pos++
+  } else {
+    //
+    // Link reference
+    //
+    if (typeof state.env.references === 'undefined') { return false }
+
+    if (pos < max && state.src.charCodeAt(pos) === 0x5B/* [ */) {
+      start = pos + 1
+      pos = state.md.helpers.parseLinkLabel(state, pos)
+      if (pos >= 0) {
+        label = state.src.slice(start, pos++)
+      } else {
+        pos = labelEnd + 1
+      }
+    } else {
+      pos = labelEnd + 1
+    }
+
+    // covers label === '' and label === undefined
+    // (collapsed reference link and shortcut reference link respectively)
+    if (!label) { label = state.src.slice(labelStart, labelEnd) }
+
+    ref = state.env.references[normalizeReference(label)]
+    if (!ref) {
+      state.pos = oldPos
+      return false
+    }
+    href = ref.href
+    title = ref.title
+  }
+
+  //
+  // We found the end of the link, and know for a fact it's a valid link;
+  // so all that's left to do is to call tokenizer.
+  //
+  if (!silent) {
+    content = state.src.slice(labelStart, labelEnd)
+
+    state.md.inline.parse(
+      content,
+      state.md,
+      state.env,
+      tokens = []
+    )
+
+    token = state.push('image', 'img', 0)
+    token.attrs = attrs = [ [ 'src', href ], [ 'alt', '' ] ]
+    token.children = tokens
+    token.content = content
+
+    if (title) {
+      attrs.push([ 'title', title ])
+    }
+  }
+
+  state.pos = pos
+  state.posMax = max
+  return true
+}

--- a/lib/gfm/link.js
+++ b/lib/gfm/link.js
@@ -1,0 +1,186 @@
+// CommonMark specifies that links have no whitespace between the label and
+// destination, e.g.:
+//
+//     [link text](path/to/the/thing)
+//
+// However, GitHub allows you to put whitespace between the `]` and `(`
+// characters, like so:
+//
+//     [link text]    (path/to/the/thing)
+//
+// This is against CommonMark because it's ambiguous. Consider a link reference
+// followed by a parenthetical statement:
+//
+//     [link text] (parenthetical statement)
+//
+//     [link text]: path/to/the/thing
+//
+// CommonMark renders: <a href="path/to/the/thing">link text</a>
+// GitHub renders:     <a href="parenthetical%20statement">link text</a>
+//
+// To account for the difference, we need to override markdown-it's link rule.
+// This file is a copy of the original markdown-it source, plus the necessary
+// modifications, wrapped as a markdown-it plugin.
+
+// Process [link](<to> "stuff")
+'use strict'
+
+module.exports = function (md) {
+  md.inline.ruler.at('link', link)
+}
+
+function link (state, silent) {
+  var attrs
+  var code
+  var label
+  var labelEnd
+  var labelStart
+  var pos
+  var res
+  var ref
+  var title
+  var token
+  var href = ''
+  var oldPos = state.pos
+  var max = state.posMax
+  var start = state.pos
+  var parseReference = true
+  var isSpace = state.md.utils.isSpace
+  var normalizeReference = state.md.utils.normalizeReference
+
+  if (state.src.charCodeAt(state.pos) !== 0x5B/* [ */) { return false }
+
+  labelStart = state.pos + 1
+  labelEnd = state.md.helpers.parseLinkLabel(state, state.pos, true)
+
+  // parser failed to find ']', so it's not a valid link
+  if (labelEnd < 0) { return false }
+
+  pos = labelEnd + 1
+
+  // BEGIN CUSTOM MODIFICATION
+  // look ahead to see if the next non-whitespace character is '(', and if
+  // it is, skip the whitespace
+  for (; pos < max; pos++) {
+    code = state.src.charCodeAt(pos)
+    if (!isSpace(code) && code !== 0x0A) { break }
+  }
+  if (pos < max && state.src.charCodeAt(pos) !== 0x28) { pos = labelEnd + 1 }
+  // END CUSTOM MODIFICATION
+
+  if (pos < max && state.src.charCodeAt(pos) === 0x28/* ( */) {
+    //
+    // Inline link
+    //
+
+    // might have found a valid shortcut link, disable reference parsing
+    parseReference = false
+
+    // [link](  <href>  "title"  )
+    //        ^^ skipping these spaces
+    pos++
+    for (; pos < max; pos++) {
+      code = state.src.charCodeAt(pos)
+      if (!isSpace(code) && code !== 0x0A) { break }
+    }
+    if (pos >= max) { return false }
+
+    // [link](  <href>  "title"  )
+    //          ^^^^^^ parsing link destination
+    start = pos
+    res = state.md.helpers.parseLinkDestination(state.src, pos, state.posMax)
+    if (res.ok) {
+      href = state.md.normalizeLink(res.str)
+      if (state.md.validateLink(href)) {
+        pos = res.pos
+      } else {
+        href = ''
+      }
+    }
+
+    // [link](  <href>  "title"  )
+    //                ^^ skipping these spaces
+    start = pos
+    for (; pos < max; pos++) {
+      code = state.src.charCodeAt(pos)
+      if (!isSpace(code) && code !== 0x0A) { break }
+    }
+
+    // [link](  <href>  "title"  )
+    //                  ^^^^^^^ parsing link title
+    res = state.md.helpers.parseLinkTitle(state.src, pos, state.posMax)
+    if (pos < max && start !== pos && res.ok) {
+      title = res.str
+      pos = res.pos
+
+      // [link](  <href>  "title"  )
+      //                         ^^ skipping these spaces
+      for (; pos < max; pos++) {
+        code = state.src.charCodeAt(pos)
+        if (!isSpace(code) && code !== 0x0A) { break }
+      }
+    } else {
+      title = ''
+    }
+
+    if (pos >= max || state.src.charCodeAt(pos) !== 0x29/* ) */) {
+      // parsing a valid shortcut link failed, fallback to reference
+      parseReference = true
+    }
+    pos++
+  }
+
+  if (parseReference) {
+    //
+    // Link reference
+    //
+    if (typeof state.env.references === 'undefined') { return false }
+
+    if (pos < max && state.src.charCodeAt(pos) === 0x5B/* [ */) {
+      start = pos + 1
+      pos = state.md.helpers.parseLinkLabel(state, pos)
+      if (pos >= 0) {
+        label = state.src.slice(start, pos++)
+      } else {
+        pos = labelEnd + 1
+      }
+    } else {
+      pos = labelEnd + 1
+    }
+
+    // covers label === '' and label === undefined
+    // (collapsed reference link and shortcut reference link respectively)
+    if (!label) { label = state.src.slice(labelStart, labelEnd) }
+
+    ref = state.env.references[normalizeReference(label)]
+    if (!ref) {
+      state.pos = oldPos
+      return false
+    }
+    href = ref.href
+    title = ref.title
+  }
+
+  //
+  // We found the end of the link, and know for a fact it's a valid link;
+  // so all that's left to do is to call tokenizer.
+  //
+  if (!silent) {
+    state.pos = labelStart
+    state.posMax = labelEnd
+
+    token = state.push('link_open', 'a', 1)
+    token.attrs = attrs = [ [ 'href', href ] ]
+    if (title) {
+      attrs.push([ 'title', title ])
+    }
+
+    state.md.inline.tokenize(state)
+
+    token = state.push('link_close', 'a', -1)
+  }
+
+  state.pos = pos
+  state.posMax = max
+  return true
+}

--- a/lib/render.js
+++ b/lib/render.js
@@ -19,6 +19,8 @@ var htmlHeading = require('./plugin/html-heading')
 var relaxedLinkRefs = require('./gfm/relaxed-link-reference')
 var githubHeadings = require('./gfm/indented-headings')
 var overrideLinkDestinationParser = require('./gfm/override-link-destination-parser')
+var looseLinkParsing = require('./gfm/link')
+var looseImageParsing = require('./gfm/image')
 
 if (typeof process.browser === 'undefined') {
   var Highlights = require('highlights')
@@ -81,6 +83,8 @@ render.getParser = function (options) {
     .use(packagize, {package: options.package})
     .use(htmlHeading)
     .use(overrideLinkDestinationParser)
+    .use(looseLinkParsing)
+    .use(looseImageParsing)
 
   if (options.highlightSyntax) parser.use(codeWrap)
   if (options.serveImagesWithCDN) parser.use(cdnImages, {package: options.package})

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -115,6 +115,40 @@ describe('markdown processing', function () {
         assert(~tables.indexOf('<td><code>\\|</code></td>'))
       })
     })
+
+    describe('loose link labels', function () {
+      it('still parses link references properly', function () {
+        var markdown = 'a [link] here\n\n[link]: #destination'
+        var $ = cheerio.load(marky(markdown))
+        assert($('a[href="#destination"]').length)
+      })
+
+      it('allows whitespace between link labels and destinations', function () {
+        var markdown = 'a [link] (#destination) here'
+        var $ = cheerio.load(marky(markdown))
+        assert($('a[href="#destination"]').length)
+      })
+
+      it('allows whitespace between image text and src', function () {
+        var markdown = 'an image: ![alt] (path/to/image)'
+        var $ = cheerio.load(marky(markdown))
+        assert($('img[src="path/to/image"]').length)
+      })
+
+      it('allows whitespace in linked images with whitespace between text and src', function () {
+        var markdown = 'an image: [ ![alt] (path/to/image) ] (path/to/link)'
+        var $ = cheerio.load(marky(markdown))
+        assert($('img[src="path/to/image"]').length)
+        assert($('a[href="path/to/link"]').length)
+      })
+
+      it('allows loose link labels to override link references', function () {
+        var markdown = 'a [link] (or is it) here\n\n[link]: #destination'
+        var $ = cheerio.load(marky(markdown))
+        assert(!$('a[href="#destination"]').length)
+        assert($('a[href="or%20is%20it"]').length)
+      })
+    })
   })
 
   describe('syntax highlighting', function () {
@@ -272,14 +306,14 @@ describe('markdown processing', function () {
     })
 
     it('linkifies bracketed/parenthetical hostnames', function () {
-      var $ = cheerio.load(marky('[www.example.com] \n (www.example2.com) \n {www.do-not-link.com}'))
+      var $ = cheerio.load(marky('[www.example.com] \n {www.do-no-link.com} \n (www.example2.com)'))
       assert($("a[href='http://www.example.com']").length)
       assert($("a[href='http://www.example2.com']").length)
       assert(!$("a[href='http://www.do-not-link.com']").length)
     })
 
     it('includes path components', function () {
-      var $ = cheerio.load(marky('www.example.name/marky/markdown [www.example.name/marky/markdown] (www.example.name/marky/markdown)'))
+      var $ = cheerio.load(marky('[www.example.name/marky/markdown] www.example.name/marky/markdown (www.example.name/marky/markdown)'))
       assert.equal($("a[href='http://www.example.name/marky/markdown']").length, 3)
     })
 


### PR DESCRIPTION
It's kind of a bummer, but the type of looser parsing github does on links and images requires us to completely overwrite the markdown-it image and link rules. So, here it is.

Fixes #328