### PR TITLE
Use innerHTML rather than innerText in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Here is an example using HTML5 to render text inside `<marky-markdown>` tags.
 
 <script>
   for (el of document.getElementsByTagName('marky-markdown')) {
-    el.innerHTML = markyMarkdown(el.innerText, {highlightSyntax: false})
+    el.innerHTML = markyMarkdown(el.innerHTML, {highlightSyntax: false})
   }
 </script>
 ```


### PR DESCRIPTION
Fixes #334.