### PR TITLE
Add comment with marky version and issues URL to rendered HTML in debug mode

### DIFF
--- a/bin/build-marky-info.js
+++ b/bin/build-marky-info.js
@@ -1,0 +1,15 @@
+var fs = require('fs')
+var markyPackage = require('../package.json')
+
+var info = {
+  version: markyPackage.version,
+  repositoryUrl: markyPackage.repository.url,
+  issuesUrl: markyPackage.repository.url + '/issues'
+}
+
+var contents = JSON.stringify(info)
+
+fs.writeFile('marky.json', contents, function (err) {
+  if (err) throw err
+  console.log('Built marky.json. ' + contents)
+})

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var defaults = require('lodash.defaults')
 var isPlainObj = require('is-plain-obj')
 var render = require('./lib/render')
 var sanitize = require('./lib/sanitize')
+var markyInfo = require('./marky.json')
 
 var defaultOptions = {
   sanitize: true,
@@ -41,6 +42,18 @@ var marky = module.exports = function (markdown, options) {
   if (options.sanitize) {
     log('Sanitize malicious or malformed HTML')
     html = sanitize(html)
+  }
+
+  if (options.debug) {
+    var debugHeader =
+      '<!--' +
+      ' this HTML was generated using marky-markdown version ' + markyInfo.version + '.' +
+      ' see an issue? file at ' + markyInfo.issuesUrl + '.' +
+      ' please include the version in your issue. thanks for using marky!' +
+      ' to learn more, visit ' + markyInfo.repositoryUrl + '.' +
+      '  -->'
+
+    html = debugHeader + '\n' + html
   }
 
   return html

--- a/marky.json
+++ b/marky.json
@@ -1,0 +1,1 @@
+{"version":"9.0.1","repositoryUrl":"https://github.com/npm/marky-markdown","issuesUrl":"https://github.com/npm/marky-markdown/issues"}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "npm's markdown parser",
   "main": "index.js",
   "scripts": {
+    "prebuild": "node bin/build-marky-info.js",
     "build": "rm -rf dist && mkdir dist && touch dist/marky-markdown.js && browserify index.js -i highlights -s markyMarkdown > dist/marky-markdown.js",
     "test": "standard --fix && mocha --timeout 8000",
-    "pretest": "npm run build"
+    "pretest": "npm run build",
+    "postversion": "node bin/build-marky-info.js && npm run build"
   },
   "browser": {
     "highlights": false


### PR DESCRIPTION
Fixes #344.

This does result in the contents of our package.json being included in the browserify build. Do we care about that at all?