### PR TITLE
Bump markdown-it-task-lists to 2.0.0

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -38,12 +38,12 @@ sanitizer.config = {
     h6: ['deep-link'],
     input: ['task-list-item-checkbox'],
     li: ['task-list-item'],
-    ol: ['task-list'],
+    ol: ['contains-task-list'],
     p: ['package-description-redundant'],
     pre: ['editor', 'editor-colors'],
     span: require('./highlights-tokens'),
     svg: ['octicon', 'octicon-link'],
-    ul: ['task-list']
+    ul: ['contains-task-list']
   },
   allowedAttributes: {
     h1: ['id'],

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "markdown-it-emoji": "^1.3.0",
     "markdown-it-expand-tabs": "^1.0.7",
     "markdown-it-lazy-headers": "^0.1.3",
-    "markdown-it-task-lists": "^1.0.0",
+    "markdown-it-task-lists": "^2.0.0",
     "property-ttl": "^1.0.0",
     "sanitize-html": "^1.6.1",
     "similarity": "^1.0.1"

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -76,12 +76,12 @@ describe('markdown processing', function () {
         assert(~$todo('li.task-list-item').length)
       })
 
-      it('adds class .task-list to lists', function () {
-        assert(~$todo('ol.task-list, ul.task-list').length)
+      it('adds class .contains-task-list to lists', function () {
+        assert(~$todo('ol.contains-task-list, ul.contains-task-list').length)
       })
 
-      it('only adds .task-list to most immediate parent list', function () {
-        assert($todo('ol:not(.task-list) ul.task-list').length)
+      it('only adds .contains-task-list to most immediate parent list', function () {
+        assert($todo('ol:not(.contains-task-list) ul.contains-task-list').length)
       })
     })
 


### PR DESCRIPTION
* Updates to markdown-it-task-lists 2.0
* Fixes a couple of tests that broke because of the changed markup (`.contains-task-list` rather than `.task-list` on the list elements)
* Updates the sanitizer accordingly