### PR TITLE
Add oniguruma 6.1.1 explicitly as a devDependency to keep node 4 working

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "glob": "^7.1.1",
     "intercept-stdout": "^0.1.2",
     "mocha": "^3.1.2",
+    "oniguruma": "~6.1.1",
     "standard": "^10.0.0"
   },
   "bin": "./bin/marky-markdown.js",


### PR DESCRIPTION
At least for now, we still support node 4, which means oniguruma 6.2 breaks our build because it requires ES6 features. It's a dependency of a dependency, but if we add 6.1.1 explicitly as a devDependency, marky still works on node 4. So here's that.