### PR TITLE
Support shortcut github paths in URL rewrites

### DIFF
--- a/lib/plugin/github.js
+++ b/lib/plugin/github.js
@@ -49,7 +49,7 @@ module.exports = function (md, opts) {
   if (!opts.package) return
   if (!opts.package.repository) return
 
-  var repo = gh(opts.package.repository.url)
+  var repo = gh(opts.package.repository)
 
   if (!repo) return
 

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -130,6 +130,6 @@ function prefixHTMLids (tagName, attribs) {
   return {tagName, attribs}
 }
 
-function isAlreadyPrefixed(id, prefix) {
+function isAlreadyPrefixed (id, prefix) {
   return id.includes(prefix) && id.length > prefix.length
 }

--- a/test/repo-github.js
+++ b/test/repo-github.js
@@ -7,6 +7,7 @@ var cheerio = require('cheerio')
 
 describe('when package repo is on github', function () {
   var $
+  var $short
   var pkg = {
     name: 'wahlberg',
     repository: {
@@ -14,14 +15,20 @@ describe('when package repo is on github', function () {
       url: 'https://github.com/mark/wahlberg'
     }
   }
+  var shortPkg = {
+    name: 'wahlberg',
+    repository: 'mark/wahlberg'
+  }
 
   before(function () {
     $ = cheerio.load(marky(fixtures.github, {package: pkg}))
+    $short = cheerio.load(marky(fixtures.github, {package: shortPkg}))
   })
 
   it('rewrites relative link hrefs to absolute', function () {
     assert(~fixtures.github.indexOf('(relative/file.js)'))
     assert($("a[href='https://github.com/mark/wahlberg/blob/HEAD/relative/file.js']").length)
+    assert($short("a[href='https://github.com/mark/wahlberg/blob/HEAD/relative/file.js']").length)
   })
 
   it('rewrites relative link hrefs to absolute (HTML)', function () {
@@ -29,11 +36,14 @@ describe('when package repo is on github', function () {
     assert(~fixtures.github.indexOf('<a href="html-page-and-image.html">'))
     assert($("a[href='https://github.com/mark/wahlberg/blob/HEAD/html-page.html']").length)
     assert($("a[href='https://github.com/mark/wahlberg/blob/HEAD/html-page-and-image.html']").length)
+    assert($short("a[href='https://github.com/mark/wahlberg/blob/HEAD/html-page.html']").length)
+    assert($short("a[href='https://github.com/mark/wahlberg/blob/HEAD/html-page-and-image.html']").length)
   })
 
   it('rewrites slashy relative links hrefs to absolute', function () {
     assert(~fixtures.github.indexOf('(/slashy/poo)'))
     assert($("a[href='https://github.com/mark/wahlberg/blob/HEAD/slashy/poo']").length)
+    assert($short("a[href='https://github.com/mark/wahlberg/blob/HEAD/slashy/poo']").length)
   })
 
   it('rewrites slashy relative links hrefs to absolute (HTML)', function () {
@@ -41,21 +51,26 @@ describe('when package repo is on github', function () {
     assert(~fixtures.github.indexOf('<a href="html/block.html">Link in an HTML block</a>'))
     assert($("a[href='https://github.com/mark/wahlberg/blob/HEAD/nested/link/image']").length)
     assert($("a[href='https://github.com/mark/wahlberg/blob/HEAD/html/block.html']").length)
+    assert($short("a[href='https://github.com/mark/wahlberg/blob/HEAD/nested/link/image']").length)
+    assert($short("a[href='https://github.com/mark/wahlberg/blob/HEAD/html/block.html']").length)
   })
 
   it('leaves protocol-relative URLs alone', function () {
     assert(~fixtures.github.indexOf('(//protocollie.com)'))
     assert($("a[href='//protocollie.com']").length)
+    assert($short("a[href='//protocollie.com']").length)
   })
 
   it('leaves hashy URLs alone', function () {
     assert(~fixtures.github.indexOf('(#header)'))
     assert($("a[href='#header']").length)
+    assert($short("a[href='#header']").length)
   })
 
   it('replaces relative img URLs with github URLs', function () {
     assert(~fixtures.github.indexOf('![](relative.png)'))
     assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/relative.png']").length)
+    assert($short("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/relative.png']").length)
   })
 
   it('replaces relative img URLs with github URLs (HTML)', function () {
@@ -63,11 +78,14 @@ describe('when package repo is on github', function () {
     assert(~fixtures.github.indexOf('<img src="html-page-and-image.png" alt="alt text">'))
     assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/html-image.png']").length)
     assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/html-page-and-image.png']").length)
+    assert($short("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/html-image.png']").length)
+    assert($short("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/html-page-and-image.png']").length)
   })
 
   it('replaces slashy relative img URLs with github URLs', function () {
     assert(~fixtures.github.indexOf('![](/slashy/deep.png)'))
     assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/slashy/deep.png']").length)
+    assert($short("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/slashy/deep.png']").length)
   })
 
   it('replaces slashy relative img URLs with github URLs (HTML)', function () {
@@ -75,15 +93,19 @@ describe('when package repo is on github', function () {
     assert(~fixtures.github.indexOf('<img src="html/block.png" />'))
     assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/nested/link/image/image.png']").length)
     assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/html/block.png']").length)
+    assert($short("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/nested/link/image/image.png']").length)
+    assert($short("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/html/block.png']").length)
   })
 
   it('leaves protocol relative URLs alone', function () {
     assert(~fixtures.github.indexOf('![](//protocollie.com/woof.png)'))
     assert($("img[src='//protocollie.com/woof.png']").length)
+    assert($short("img[src='//protocollie.com/woof.png']").length)
   })
 
   it('leaves HTTPS URLs alone', function () {
     assert(~fixtures.github.indexOf('![](https://secure.com/good.png)'))
     assert($("img[src='https://secure.com/good.png']").length)
+    assert($short("img[src='https://secure.com/good.png']").length)
   })
 })


### PR DESCRIPTION
Fixes #368 by falling back to `opts.package.repository` if `opts.package.repository.url` is falsy.