### PR TITLE
chore: working on drafting a 10.x release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
-# 10.0.0 (2017-06-26)
+# 10.0.0 (2017-05-26)
+
+We're fine tuning a lot of small but noticeable behavioral differences between
+our renderer and GitHub's, as we discover situations where GitHub differs from
+CommonMark. The closer we get to full GitHub compatibility, the edge-case-ier
+our changes become. Without a doubt, version 10 is the edge-case-fix-iest
+release of marky-markdown yet!
+
+## Breaking Changes
+
+- links generated in headers are created differently:
+  - links now use class `anchor` rather than `deep-link`. ([pull/289])
+  - SVG icons in links now use class `octicon` and `octicon-link` rather than
+    `deep-link-icon`. ([pull/292])
+  - headings now have `aria-hidden=true`. ([pull/293])
+- we no longer do special processing on badge images. ([pull/303])
+- any options provided must now be an object. ([pull/323])
+- ids in user generated HTML are now prefixed. ([pull/358])
 
 ## Features
 
-- spaces are now supported in image and url paths, thanks [sjking]! ([pull/280]).
+- spaces are now supported in image and url paths, thanks [sjking]! ([pull/280])
+- new `getParser` method to provide access to the underlying markdown-it parser
+  instance in case you want to use [custom markdown-it plugins] in your own
+  apps. ([pull/285], [pull/287]; see [low level parser access])
 - marky-markdown now understands relative GitHub links, e.g., `[logo](/logo.png)` 😄 ([pull/308])
 - support for spaces between link labels and paths. ([pull/329])
 - `details` and `summary` are now white-listed HTML tags. ([pull/333])
@@ -13,6 +33,7 @@
 
 ## Fixes
 
+- stop stripping `style` attributes from `img` elements. ([pull/299])
 - HTML blocks are no longer greedy. ([pull/325])
 - syntax highlighting no longer applied if no language is specified in code block. ([pull/327])
 - headings can now interrupt paragraphs, and will be rendered appropriately. ([pull/326])
@@ -21,6 +42,15 @@
 - enforce that if options are passed, they must be an object. ([pull/323])
 
 [pull/280]: https://github.com/npm/marky-markdown/pull/280
+[custom markdown-it plugins]: https://www.npmjs.com/search?q=markdown-it-plugin
+[low level parser access]: https://github.com/npm/marky-markdown/tree/abc7919e840977efaf4e9212879339b258981db0#low-level-parser-access
+[pull/285]: https://github.com/npm/marky-markdown/pull/285
+[pull/287]: https://github.com/npm/marky-markdown/pull/287
+[pull/289]: https://github.com/npm/marky-markdown/pull/289
+[pull/292]: https://github.com/npm/marky-markdown/pull/292
+[pull/293]: https://github.com/npm/marky-markdown/pull/293
+[pull/299]: https://github.com/npm/marky-markdown/pull/299
+[pull/303]: https://github.com/npm/marky-markdown/pull/303
 [pull/308]: https://github.com/npm/marky-markdown/pull/308
 [pull/316]: https://github.com/npm/marky-markdown/pull/316
 [pull/322]: https://github.com/npm/marky-markdown/pull/322
@@ -35,11 +65,6 @@
 [pull/358]: https://github.com/npm/marky-markdown/pull/358
 [pull/369]: https://github.com/npm/marky-markdown/pull/369
 [zkat]: https://github.com/zkat
-
-## Breaking Changes
-
-- any options provided must now be an object. ([pull/323])
-- ids in user generated HTML are now prefixed. ([pull/358])
 
 # 9.0.3 (2017-04-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 - spaces are now supported in image and url paths, thanks [sjking]! ([pull/280]).
 - marky-markdown now understands relative GitHub links, e.g., `[logo](/logo.png)` 😄 ([pull/308])
 - support for spaces between link labels and paths. ([pull/329])
-- `details` and `summary` are now white-listed HTML tags (([pull/333]))
+- `details` and `summary` are now white-listed HTML tags ([pull/333])
 
 ## Fixes
 
-- HTML blocks are no longer greedy.([pull/325])
-- syntax highlighting no longer applied if no language is specified in code block ([pull/327])
-- headings can now interrupt paragraphs, and will be rendered appropriately ([pull/326])
+- HTML blocks are no longer greedy. ([pull/325])
+- syntax highlighting no longer applied if no language is specified in code block. ([pull/327])
+- headings can now interrupt paragraphs, and will be rendered appropriately .([pull/326])
 - markdown-it now properly renders tables with internal code blocks. ([pull/316])
 - enforce that if options are passed, they must be an object. ([pull/323])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ## Breaking Changes
 
-- any options provided must now be an object. ([pull/323]).
+- any options provided must now be an object. ([pull/323])
 - ids in user generated HTML are now prefixed. ([pull/358])
 
 # 9.0.1 (2016-10-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+# 10.0.0 (2017-06-26)
+
+## Features
+
+- spaces are now supported in image and url paths, thanks [sjking]! ([pull/280]).
+- marky-markdown now understands relative GitHub links, e.g., `[logo](/logo.png)` 😄 ([pull/308])
+- support for spaces between link labels and paths. ([pull/329])
+- `details` and `summary` are now white-listed HTML tags (([pull/333]))
+
+## Fixes
+
+- HTML blocks are no longer greedy.([pull/325])
+- syntax highlighting no longer applied if no language is specified in code block ([pull/327])
+- headings can now interrupt paragraphs, and will be rendered appropriately ([pull/326])
+- markdown-it now properly renders tables with internal code blocks. ([pull/316])
+- enforce that if options are passed, they must be an object. ([pull/323])
+
+[pull/280]: https://github.com/npm/marky-markdown/pull/280
+[pull/308]: https://github.com/npm/marky-markdown/pull/308
+[pull/316]: https://github.com/npm/marky-markdown/pull/316
+[pull/323]: https://github.com/npm/marky-markdown/pull/323
+[pull/325]: https://github.com/npm/marky-markdown/pull/325
+[pull/326]: https://github.com/npm/marky-markdown/pull/326
+[pull/327]: https://github.com/npm/marky-markdown/pull/327
+[pull/329]: https://github.com/npm/marky-markdown/pull/329
+[pull/333]: https://github.com/npm/marky-markdown/pull/333
+
+## Breaking Changes
+
+- any options provided must now be an object ([pull/323]).
+
 # 9.0.1 (2016-10-31)
 
 ### Bug Fix! 🐞
@@ -160,7 +191,7 @@ changes implemented in [markdown-it 8.0.0]. The main updates are:
 
 - Table troubles be gone! Or at least, any troubles with text-alignment.
   Marky was stripping `style` attributes from `<td>` and `<th>` elements-
-  and thanks to [revin]'s hardwork, it isn't anymore! 
+  and thanks to [revin]'s hardwork, it isn't anymore!
   ([issues/212], [pull/216])
 
 ### Docs
@@ -367,9 +398,9 @@ Due to the update to `markdown-it` (see below), our markdown parsing now uses Co
 
 ### Tests
 
-- originally we were installing some packages as `devDependencies` in 
+- originally we were installing some packages as `devDependencies` in
   order to use their `README`s in tests. this became an issue when
-  greenkeeper would attempt to update them and break our tests :) 
+  greenkeeper would attempt to update them and break our tests :)
   we now have pulled in the `README`s as static assets ([issue/91]
   [pull/114]), by [revin]
 - tests were all in a single file, broken up in categories
@@ -394,7 +425,7 @@ Due to the update to `markdown-it` (see below), our markdown parsing now uses Co
 ### Bug Fixes
 
 - any URL containing "//youtube.com" was make it through our iframe
-  filter, but the intent was to only allow actual YouTube URLs. 
+  filter, but the intent was to only allow actual YouTube URLs.
   ([issue/108], [pull/110]), filed by [lovasoa],  solved by [revin]
 
 [lovasoa]: https://github.com/lovasoa
@@ -435,7 +466,7 @@ Due to the update to `markdown-it` (see below), our markdown parsing now uses Co
 - we strip `h1` tags from `README`s that have the same content as the
   package name, however we did not update this feature to account for
   scoped package names, e.g. @scope/pkg. now we remove the scope from
-  the package meta-data to check the `README`'s `h1`. 
+  the package meta-data to check the `README`'s `h1`.
   ([issue/48][pull/103]) - reported by [sindresorhus], solved by [revin]
 
 ### Documentation
@@ -456,7 +487,7 @@ Due to the update to `markdown-it` (see below), our markdown parsing now uses Co
 ### Bug Fix
 
 - we were parsing `:)` into emoji, though this is not the desired behavior.
-  disabled shortcut emoji parsing in the markdown-it-emoji plugin. 
+  disabled shortcut emoji parsing in the markdown-it-emoji plugin.
   ([issue/95], [pull/97]) - reported by [cloakedninjas], solved by [revin]
 
 # 6.0.1 (2016-01-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 - spaces are now supported in image and url paths, thanks [sjking]! ([pull/280]).
 - marky-markdown now understands relative GitHub links, e.g., `[logo](/logo.png)` 😄 ([pull/308])
 - support for spaces between link labels and paths. ([pull/329])
-- `details` and `summary` are now white-listed HTML tags ([pull/333])
+- `details` and `summary` are now white-listed HTML tags. ([pull/333])
+- support for GitHub repos that have no master branch. thanks [zkat]! ([pull/351])
+- **security:** ids in user generated HTML are now prefixed. ([pull/358])
+- add debug information to footer if debug is enabled. ([pull/346])
+- support string repository shorthand in package.json. ([pull/369])
 
 ## Fixes
 
@@ -13,21 +17,29 @@
 - syntax highlighting no longer applied if no language is specified in code block. ([pull/327])
 - headings can now interrupt paragraphs, and will be rendered appropriately. ([pull/326])
 - markdown-it now properly renders tables with internal code blocks. ([pull/316])
+- fix bug with relative images and links. ([pull/323])
 - enforce that if options are passed, they must be an object. ([pull/323])
 
 [pull/280]: https://github.com/npm/marky-markdown/pull/280
 [pull/308]: https://github.com/npm/marky-markdown/pull/308
 [pull/316]: https://github.com/npm/marky-markdown/pull/316
+[pull/322]: https://github.com/npm/marky-markdown/pull/322
 [pull/323]: https://github.com/npm/marky-markdown/pull/323
 [pull/325]: https://github.com/npm/marky-markdown/pull/325
 [pull/326]: https://github.com/npm/marky-markdown/pull/326
 [pull/327]: https://github.com/npm/marky-markdown/pull/327
 [pull/329]: https://github.com/npm/marky-markdown/pull/329
 [pull/333]: https://github.com/npm/marky-markdown/pull/333
+[pull/346]: https://github.com/npm/marky-markdown/pull/346
+[pull/351]: https://github.com/npm/marky-markdown/pull/351
+[pull/358]: https://github.com/npm/marky-markdown/pull/358
+[pull/369]: https://github.com/npm/marky-markdown/pull/369
+[zkat]: https://github.com/zkat
 
 ## Breaking Changes
 
-- any options provided must now be an object ([pull/323]).
+- any options provided must now be an object. ([pull/323]).
+- ids in user generated HTML are now prefixed. ([pull/358])
 
 # 9.0.1 (2016-10-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,22 @@
 - any options provided must now be an object. ([pull/323])
 - ids in user generated HTML are now prefixed. ([pull/358])
 
+# 9.0.3 (2017-04-12)
+
+### Bug Fix! 🐛
+
+- Updated sanitization to ensure that user-generated ids that are in HTML
+  blocks are also prefixed. ([pull/357])
+
+[pull/357]: https://github.com/npm/marky-markdown/pull/357
+
+# 9.0.2 (2017-03-03)
+
+### Dependencies
+
+- Bumped `highlights` to `2.1.3` because a new version of its dep `fs-plus` 
+  broke Node 4 builds
+
 # 9.0.1 (2016-10-31)
 
 ### Bug Fix! 🐞

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - HTML blocks are no longer greedy. ([pull/325])
 - syntax highlighting no longer applied if no language is specified in code block. ([pull/327])
-- headings can now interrupt paragraphs, and will be rendered appropriately .([pull/326])
+- headings can now interrupt paragraphs, and will be rendered appropriately. ([pull/326])
 - markdown-it now properly renders tables with internal code blocks. ([pull/316])
 - enforce that if options are passed, they must be an object. ([pull/323])
 


### PR DESCRIPTION
working on drafting the CHANGELOG for a 10.x release -- can't wait to try out some of @revin's changes that bring us closer to GitHub flavored markdown on npmjs.com; the impetus partially being that @zkat and myself are bumping into some rendering issues on our own READMEs.

How would folks feel about moving to http://conventionalcommits.org/ for future releases, so that CHANGELOG generation is less tedious.

