### PR TITLE
Change ES6 object shorthand to ES5 so browserify bundle works

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -127,7 +127,10 @@ function prefixHTMLids (tagName, attribs) {
   if (attribs.id && !isAlreadyPrefixed(attribs.id, 'user-content-')) {
     attribs.id = 'user-content-' + attribs.id
   }
-  return {tagName, attribs}
+  return {
+    tagName: tagName,
+    attribs: attribs
+  }
 }
 
 function isAlreadyPrefixed (id, prefix) {


### PR DESCRIPTION
This is the only place I found that broke browserify. Hopefully that's all there is; I didn't read every single line of code in the project 😛 

Fixes #371 
