### PR TITLE
Use node 8 on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ notifications:
 node_js:
   - 4
   - 6
+  - 8
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
Now that [node 8](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.0.0) is out, may as well use it in CI