### PR TITLE
feat: heading anchor class to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![Issue Stats](http://issuestats.com/github/npm/marky-markdown/badge/pr)](http://issuestats.com/github/npm/marky-markdown)
 [![Issue Stats](http://issuestats.com/github/npm/marky-markdown/badge/issue)](http://issuestats.com/github/npm/marky-markdown)
 
-`marky-markdown` is a markdown parser, written in NodeJS, that aims for 
+`marky-markdown` is a markdown parser, written in NodeJS, that aims for
 parity with [GitHub-style markdown]. It is built on top of [`markdown-it`],
-a [CommonMark] markdown parser. You can use marky-markdown: 
+a [CommonMark] markdown parser. You can use marky-markdown:
 
 - [programmatically in NodeJS]
 - [in your terminal]
 - [in the browser] *does not yet support syntax highlighting
 
-`marky-markdown` is the thing that parses package READMEs on 
+`marky-markdown` is the thing that parses package READMEs on
 http://www.npmjs.com. If you see a markdown parsing bug there,
 [file an issue here]!
 
@@ -29,7 +29,7 @@ http://www.npmjs.com. If you see a markdown parsing bug there,
 ## Node Version Support
 
 marky-markdown strives to support all LTS, current, and maintenance
-versions of Node.js. When a version of Node.js is EOL, we will EOL 
+versions of Node.js. When a version of Node.js is EOL, we will EOL
 support for that version for marky-markdown.
 
 For more information on Node.js LTS and support, click [here](https://github.com/nodejs/LTS).
@@ -73,7 +73,8 @@ The default options are as follows:
   enableHeadingLinkIcons: true, // render icons inside generated section links
   serveImagesWithCDN: false,    // use npm's CDN to proxy images over HTTPS
   debug: false,                 // console.log() all the things
-  package: null                 // npm package metadata
+  package: null,                // npm package metadata,
+  headingClassName: 'anchor'    // the classname used for anchors in headings.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ The default options are as follows:
   serveImagesWithCDN: false,    // use npm's CDN to proxy images over HTTPS
   debug: false,                 // console.log() all the things
   package: null,                // npm package metadata,
-  headingClassName: 'anchor'    // the classname used for anchors in headings.
+  headingAnchorClass: 'anchor', // the classname used for anchors in headings.
+  headingSvgClass: ['octicon']  // the class used for svg icon in headings.
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ var defaultOptions = {
   serveImagesWithCDN: false,
   debug: false,
   package: null,
-  headingClassName: 'anchor'
+  headingAnchorClass: 'anchor',
+  headingSvgClass: ['octicon', 'octicon-link']
 }
 
 var marky = module.exports = function (markdown, options) {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ var defaultOptions = {
   enableHeadingLinkIcons: true,
   serveImagesWithCDN: false,
   debug: false,
-  package: null
+  package: null,
+  headingClassName: 'anchor'
 }
 
 var marky = module.exports = function (markdown, options) {

--- a/lib/plugin/heading-links.js
+++ b/lib/plugin/heading-links.js
@@ -6,6 +6,7 @@ var tokenUtil = require('../token-util')
 var svgLinkIconText = '<svg aria-hidden="true" class="octicon octicon-link" height="16" version="1.1" viewbox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>'
 
 var headings = module.exports = function (md, options) {
+  var headingClassName = options.headingClassName || 'anchor'
   if (options && !options.prefixHeadingIds) {
     headings.prefix = ''
   } else {
@@ -48,7 +49,7 @@ var headings = module.exports = function (md, options) {
 
       // add some link attributes
       linkOpen.attrSet('id', headings.prefix + postfix)
-      linkOpen.attrSet('class', headings.className)
+      linkOpen.attrSet('class', headingClassName)
       linkOpen.attrSet('href', '#' + postfix)
       linkOpen.attrSet('aria-hidden', 'true')
 
@@ -63,4 +64,3 @@ var headings = module.exports = function (md, options) {
 }
 
 headings.defaultPrefix = 'user-content-'
-headings.className = 'anchor'

--- a/lib/plugin/heading-links.js
+++ b/lib/plugin/heading-links.js
@@ -2,11 +2,11 @@ var GithubSlugger = require('github-slugger')
 var innertext = require('innertext')
 var tokenUtil = require('../token-util')
 
-// shamelessly borrowed from GitHub, thanks y'all
-var svgLinkIconText = '<svg aria-hidden="true" class="octicon octicon-link" height="16" version="1.1" viewbox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>'
-
 var headings = module.exports = function (md, options) {
-  var headingClassName = options.headingClassName || 'anchor'
+  var headingAnchorClass = options.headingAnchorClass || 'anchor'
+  var headingSvgClass = options.headingSvgClass || ['octicon', 'octicon-link']
+  // shamelessly borrowed from GitHub, thanks y'all
+  var svgLinkIconText = `<svg aria-hidden="true" class="${[].concat(headingSvgClass).join(' ')}" height="16" version="1.1" viewbox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`
   if (options && !options.prefixHeadingIds) {
     headings.prefix = ''
   } else {
@@ -49,7 +49,7 @@ var headings = module.exports = function (md, options) {
 
       // add some link attributes
       linkOpen.attrSet('id', headings.prefix + postfix)
-      linkOpen.attrSet('class', headingClassName)
+      linkOpen.attrSet('class', headingAnchorClass)
       linkOpen.attrSet('href', '#' + postfix)
       linkOpen.attrSet('aria-hidden', 'true')
 

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -47,7 +47,7 @@ function getSanitizerConfig (options) {
         'xml',
         'youtube-video'
       ],
-      h1: [options.headingAnchorClass, 'package-name-redundant', 'package-description-redundant'],
+      h1: ['package-name-redundant', 'package-description-redundant'],
       input: ['task-list-item-checkbox'],
       li: ['task-list-item'],
       ol: ['contains-task-list'],

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -48,11 +48,6 @@ function getSanitizerConfig (options) {
         'youtube-video'
       ],
       h1: [options.headingAnchorClass, 'package-name-redundant', 'package-description-redundant'],
-      h2: [options.headingAnchorClass],
-      h3: [options.headingAnchorClass],
-      h4: [options.headingAnchorClass],
-      h5: [options.headingAnchorClass],
-      h6: [options.headingAnchorClass],
       input: ['task-list-item-checkbox'],
       li: ['task-list-item'],
       ol: ['contains-task-list'],

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -1,8 +1,8 @@
 var sanitizeHtml = require('sanitize-html')
-var sanitizer = module.exports = function (html, options) {
+module.exports = function (html, options) {
   var config
   if (options && options.prefixHeadingIds) {
-    config = Object.assign({}, sanitizer.config, {
+    config = Object.assign({}, getSanitizerConfig(options), {
       transformTags: {
         '*': prefixHTMLids,
         'td': sanitizeCellStyle,
@@ -10,92 +10,97 @@ var sanitizer = module.exports = function (html, options) {
       }
     })
   } else {
-    config = sanitizer.config
+    config = getSanitizerConfig(options)
   }
   return sanitizeHtml(html, config)
 }
 
-sanitizer.config = {
-  allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-    'dd', 'del', 'details', 'div', 'dl', 'dt', 'h1', 'h2', 'iframe', 'img', 'input', 'ins', 'meta', 'path', 'pre', 's', 'span', 'sub', 'summary', 'sup', 'svg'
-  ]),
-  allowedClasses: {
-    a: ['anchor'],
-    div: [
-      'highlight',
-      'hljs',
-      'bash',
-      'css',
-      'coffee',
-      'coffeescript',
-      'diff',
-      'glsl',
-      'http',
-      'js',
-      'javascript',
-      'json',
-      'lang-html',
-      'line',
-      'sh',
-      'shell',
-      'typescript',
-      'xml',
-      'youtube-video'
-    ],
-    h1: ['anchor', 'package-name-redundant', 'package-description-redundant'],
-    h2: ['deep-link'],
-    h3: ['deep-link'],
-    h4: ['deep-link'],
-    h5: ['deep-link'],
-    h6: ['deep-link'],
-    input: ['task-list-item-checkbox'],
-    li: ['task-list-item'],
-    ol: ['contains-task-list'],
-    p: ['package-description-redundant'],
-    pre: ['editor', 'editor-colors'],
-    span: require('./highlights-tokens'),
-    svg: ['octicon', 'octicon-link'],
-    ul: ['contains-task-list']
-  },
-  allowedAttributes: {
-    h1: ['id'],
-    h2: ['id'],
-    h3: ['id'],
-    h4: ['id'],
-    h5: ['id'],
-    h6: ['id'],
-    a: ['href', 'id', 'name', 'target', 'title', 'aria-hidden'],
-    img: ['alt', 'id', 'src', 'width', 'height', 'align', 'valign', 'title', 'style'],
-    p: ['align'],
-    meta: ['name', 'content'],
-    iframe: ['src', 'frameborder', 'allowfullscreen'],
-    input: ['checked', 'class', 'disabled', 'type'],
-    div: ['id'],
-    span: [],
-    pre: [],
-    td: ['colspan', 'rowspan', 'style'],
-    th: ['colspan', 'rowspan', 'style'],
-    del: ['cite', 'datetime'],
-    ins: ['cite', 'datetime'],
-    path: ['d'],
-    svg: ['aria-hidden', 'height', 'version', 'viewbox', 'width']
-  },
-  exclusiveFilter: function (frame) {
-    // Allow Task List items
-    if (frame.tag === 'input') {
-      var isTaskItem = (frame.attribs.class && frame.attribs.class.indexOf('task-list-item-checkbox') > -1)
-      var isCheckbox = (frame.attribs.type && frame.attribs.type === 'checkbox')
-      var isDisabled = frame.attribs.hasOwnProperty('disabled')
-      return !(isTaskItem && isCheckbox && isDisabled)
-    }
+function getSanitizerConfig (options) {
+  options = options || {
+    headingClassName: 'anchor'
+  }
+  return {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+      'dd', 'del', 'details', 'div', 'dl', 'dt', 'h1', 'h2', 'iframe', 'img', 'input', 'ins', 'meta', 'path', 'pre', 's', 'span', 'sub', 'summary', 'sup', 'svg'
+    ]),
+    allowedClasses: {
+      a: [options.headingClassName],
+      div: [
+        'highlight',
+        'hljs',
+        'bash',
+        'css',
+        'coffee',
+        'coffeescript',
+        'diff',
+        'glsl',
+        'http',
+        'js',
+        'javascript',
+        'json',
+        'lang-html',
+        'line',
+        'sh',
+        'shell',
+        'typescript',
+        'xml',
+        'youtube-video'
+      ],
+      h1: [options.headingClassName, 'package-name-redundant', 'package-description-redundant'],
+      h2: [options.headingClassName],
+      h3: [options.headingClassName],
+      h4: [options.headingClassName],
+      h5: [options.headingClassName],
+      h6: [options.headingClassName],
+      input: ['task-list-item-checkbox'],
+      li: ['task-list-item'],
+      ol: ['contains-task-list'],
+      p: ['package-description-redundant'],
+      pre: ['editor', 'editor-colors'],
+      span: require('./highlights-tokens'),
+      svg: ['octicon', 'octicon-link'],
+      ul: ['contains-task-list']
+    },
+    allowedAttributes: {
+      h1: ['id'],
+      h2: ['id'],
+      h3: ['id'],
+      h4: ['id'],
+      h5: ['id'],
+      h6: ['id'],
+      a: ['href', 'id', 'name', 'target', 'title', 'aria-hidden'],
+      img: ['alt', 'id', 'src', 'width', 'height', 'align', 'valign', 'title', 'style'],
+      p: ['align'],
+      meta: ['name', 'content'],
+      iframe: ['src', 'frameborder', 'allowfullscreen'],
+      input: ['checked', 'class', 'disabled', 'type'],
+      div: ['id'],
+      span: [],
+      pre: [],
+      td: ['colspan', 'rowspan', 'style'],
+      th: ['colspan', 'rowspan', 'style'],
+      del: ['cite', 'datetime'],
+      ins: ['cite', 'datetime'],
+      path: ['d'],
+      svg: ['aria-hidden', 'height', 'version', 'viewbox', 'width']
+    },
+    exclusiveFilter: function (frame) {
+      // Allow Task List items
+      if (frame.tag === 'input') {
+        var isTaskItem = (frame.attribs.class && frame.attribs.class.indexOf('task-list-item-checkbox') > -1)
+        var isCheckbox = (frame.attribs.type && frame.attribs.type === 'checkbox')
+        var isDisabled = frame.attribs.hasOwnProperty('disabled')
+        return !(isTaskItem && isCheckbox && isDisabled)
+      }
 
-    // Allow YouTube iframes
-    if (frame.tag !== 'iframe') return false
-    return !String(frame.attribs.src).match(/^(https?:)?\/\/(www\.)?youtube\.com/)
-  },
-  transformTags: {
-    'td': sanitizeCellStyle,
-    'th': sanitizeCellStyle
+      // Allow YouTube iframes
+      if (frame.tag !== 'iframe') return false
+      return !String(frame.attribs.src).match(/^(https?:)?\/\/(www\.)?youtube\.com/)
+    },
+    transformTags: {
+      'td': sanitizeCellStyle,
+      'th': sanitizeCellStyle
+    }
   }
 }
 

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -17,14 +17,15 @@ module.exports = function (html, options) {
 
 function getSanitizerConfig (options) {
   options = options || {
-    headingClassName: 'anchor'
+    headingAnchorClass: 'anchor',
+    headingSvgClass: ['octicon', 'octicon-link']
   }
   return {
     allowedTags: sanitizeHtml.defaults.allowedTags.concat([
       'dd', 'del', 'details', 'div', 'dl', 'dt', 'h1', 'h2', 'iframe', 'img', 'input', 'ins', 'meta', 'path', 'pre', 's', 'span', 'sub', 'summary', 'sup', 'svg'
     ]),
     allowedClasses: {
-      a: [options.headingClassName],
+      a: [].concat(options.headingAnchorClass),
       div: [
         'highlight',
         'hljs',
@@ -46,19 +47,19 @@ function getSanitizerConfig (options) {
         'xml',
         'youtube-video'
       ],
-      h1: [options.headingClassName, 'package-name-redundant', 'package-description-redundant'],
-      h2: [options.headingClassName],
-      h3: [options.headingClassName],
-      h4: [options.headingClassName],
-      h5: [options.headingClassName],
-      h6: [options.headingClassName],
+      h1: [options.headingAnchorClass, 'package-name-redundant', 'package-description-redundant'],
+      h2: [options.headingAnchorClass],
+      h3: [options.headingAnchorClass],
+      h4: [options.headingAnchorClass],
+      h5: [options.headingAnchorClass],
+      h6: [options.headingAnchorClass],
       input: ['task-list-item-checkbox'],
       li: ['task-list-item'],
       ol: ['contains-task-list'],
       p: ['package-description-redundant'],
       pre: ['editor', 'editor-colors'],
       span: require('./highlights-tokens'),
-      svg: ['octicon', 'octicon-link'],
+      svg: [].concat(options.headingSvgClass),
       ul: ['contains-task-list']
     },
     allowedAttributes: {

--- a/test/headings.js
+++ b/test/headings.js
@@ -210,8 +210,14 @@ describe('headings', function () {
   })
 
   it('allows an alternative anchor class to be configured', function () {
-    $ = cheerio.load(marky(fixtures.dirty, {headingClassName: 'foo'}))
+    $ = cheerio.load(marky(fixtures.dirty, {headingAnchorClass: 'foo'}))
 
     assert($("h1 a.foo[href='#h1']").length)
+  })
+
+  it('allows an alternative svg class to be configured', function () {
+    $ = cheerio.load(marky(fixtures.dirty, {headingSvgClass: 'batman'}))
+
+    assert($('svg.batman').length)
   })
 })

--- a/test/headings.js
+++ b/test/headings.js
@@ -208,4 +208,10 @@ describe('headings', function () {
     $ = cheerio.load(marky(markdown, {prefixHeadingIds: false}))
     assert.equal($('h1').length, 1)
   })
+
+  it('allows an alternative anchor class to be configured', function () {
+    $ = cheerio.load(marky(fixtures.dirty, {headingClassName: 'foo'}))
+
+    assert($("h1 a.foo[href='#h1']").length)
+  })
 })


### PR DESCRIPTION
this pull allows the classname used for heading anchors to be configured, this allows the npm website to continue using the old class-name (otherwise we would either need to support both class names, or re-render the whole set of README files).