### PR TITLE
Convert ES6 template string to ES5 in heading-links

### DIFF
--- a/lib/plugin/heading-links.js
+++ b/lib/plugin/heading-links.js
@@ -5,8 +5,9 @@ var tokenUtil = require('../token-util')
 var headings = module.exports = function (md, options) {
   var headingAnchorClass = options.headingAnchorClass || 'anchor'
   var headingSvgClass = options.headingSvgClass || ['octicon', 'octicon-link']
+  var iconClasses = [].concat(headingSvgClass).join(' ')
   // shamelessly borrowed from GitHub, thanks y'all
-  var svgLinkIconText = `<svg aria-hidden="true" class="${[].concat(headingSvgClass).join(' ')}" height="16" version="1.1" viewbox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`
+  var svgLinkIconText = '<svg aria-hidden="true" class="' + iconClasses + '" height="16" version="1.1" viewbox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>'
   if (options && !options.prefixHeadingIds) {
     headings.prefix = ''
   } else {


### PR DESCRIPTION
Gets the browserify bundle working again; I keep missing these types of changes