### PR TITLE
chore: add build step using standard-version's new lifecycle scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,13 @@
     "pretest": "npm run build",
     "version": "npm run build && git add marky.json",
     "prepublish": "npm run build",
-    "release": "standard-version"
+    "release": "standard-version --commit-all"
+  },
+  "standard-version": {
+    "scripts": {
+      "postbump": "npm run build",
+      "precommit": "git add dist/marky-markdown.js marky.json"
+    }
   },
   "browser": {
     "highlights": false
@@ -73,7 +79,7 @@
     "mocha": "^3.4.1",
     "oniguruma": "~6.1.1",
     "standard": "^10.0.0",
-    "standard-version": "^4.0.0",
+    "standard-version": "^4.1.0-candidate.1",
     "tripwire": "^4.1.0"
   },
   "bin": "./bin/marky-markdown.js",

--- a/package.json
+++ b/package.json
@@ -8,14 +8,13 @@
     "build": "rm -rf dist && mkdir dist && touch dist/marky-markdown.js && browserify index.js -i highlights -s markyMarkdown > dist/marky-markdown.js",
     "test": "standard --fix && mocha --timeout 8000",
     "pretest": "npm run build",
-    "version": "npm run build && git add marky.json",
     "prepublish": "npm run build",
     "release": "standard-version --commit-all"
   },
   "standard-version": {
     "scripts": {
       "postbump": "npm run build",
-      "precommit": "git add dist/marky-markdown.js marky.json"
+      "precommit": "git add marky.json"
     }
   },
   "browser": {


### PR DESCRIPTION
use standard-version's fancy-pants new lifecycle scripts to reenable the build step.