### PR TITLE
Allow link titles to be delimited by parentheses

### DIFF
--- a/lib/gfm/override-link-destination-parser.js
+++ b/lib/gfm/override-link-destination-parser.js
@@ -49,15 +49,15 @@ function parseLinkDestination (md, str, pos, max) {
     code = str.charCodeAt(pos)
 
     if (code === 0x20) { // space
-      pos++ // 0x22 => double quote, 0x27 => single quote, 0x29 => ')'
-      while (pos < max && code !== 0x22 && code !== 0x27 && code !== 0x29) {
+      pos++ // 0x22 => double quote, 0x27 => single quote, 0x28 => '(', 0x29 => ')'
+      while (pos < max && code !== 0x22 && code !== 0x27 && code !== 0x28 && code !== 0x29) {
         code = str.charCodeAt(pos++)
       }
       pos--
       if (pos === max) { // end of the line
         break
       }
-      if (code === 0x22 || code === 0x27) { // single or double quotes for title attributes
+      if (code === 0x22 || code === 0x27 || code === 0x28) { // single/double quotes or opening paren for title attributes
         pos--
         break
       }

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -124,6 +124,17 @@ describe('markdown processing', function () {
         assert($('a[href="#destination"]').length)
       })
 
+      it('allows link titles, delimited by \'\', "", or ()', function () {
+        var markdown = 'a [one] and a [two] and a [three]'
+        markdown += '\n\n'
+        markdown += "[one]: #destination 'with a title'\n"
+        markdown += '[two]: #destination "with a title"\n'
+        markdown += '[three]: #destination (with a title)\n'
+        var $ = cheerio.load(marky(markdown))
+        assert.equal($('a').length, 3)
+        assert.equal($('a[title="with a title"]').length, 3)
+      })
+
       it('allows whitespace between link labels and destinations', function () {
         var markdown = 'a [link] (#destination) here'
         var $ = cheerio.load(marky(markdown))


### PR DESCRIPTION
Our customized link destination parser which allows link destinations to contain spaces was only considering `'` and `"` to be proper title delimiters; per CommonMark & GFM, we should allow `(` as well.

Fixes #384