### PR TITLE
Explicitly test for falsy repository.url in package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "marky-markdown",
-  "version": "10.1.1",
+  "version": "10.1.3",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {
@@ -1340,9 +1340,9 @@
       "dev": true
     },
     "github-url-to-object": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-3.1.0.tgz",
-      "integrity": "sha1-FgpdVa188EWeB1f3kS1xgHa37X0="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-4.0.0.tgz",
+      "integrity": "sha1-oze6WCGcFuqC08nMm8EJg3HG0cc="
     },
     "glob": {
       "version": "7.1.2",
@@ -2960,7 +2960,8 @@
     "tripwire": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/tripwire/-/tripwire-4.1.0.tgz",
-      "integrity": "sha1-GCG2Bh/B9RzILU26zYMz2p5TjdU="
+      "integrity": "sha1-GCG2Bh/B9RzILU26zYMz2p5TjdU=",
+      "dev": true
     },
     "tryit": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "atom-language-diff": "^1.0.0",
     "atom-language-nginx": "^0.6.1",
     "github-slugger": "^1.0.0",
-    "github-url-to-object": "^3.0.0",
+    "github-url-to-object": "^4.0.0",
     "highlights": "^2.1.1",
     "highlights-tokens": "^1.0.1",
     "innertext": "^1.0.2",

--- a/test/repo-github.js
+++ b/test/repo-github.js
@@ -108,4 +108,20 @@ describe('when package repo is on github', function () {
     assert($("img[src='https://secure.com/good.png']").length)
     assert($short("img[src='https://secure.com/good.png']").length)
   })
+
+  it('survives a falsy repository.url', function () {
+    var errorPkg = {
+      name: 'wahlberg',
+      repository: {
+        type: 'git',
+        url: undefined
+      }}
+    assert(marky(fixtures.github, {package: errorPkg}).length)
+
+    errorPkg.url = null
+    assert(marky(fixtures.github, {package: errorPkg}).length)
+
+    errorPkg.url = ''
+    assert(marky(fixtures.github, {package: errorPkg}).length)
+  })
 })


### PR DESCRIPTION
This will pass once https://github.com/zeke/github-url-to-object/pull/29 is merged/published in github-url-to-object; having this test in marky will verify that it continues to work 😄 

Fixes #386 