### PR TITLE
Add support for JSX syntax highlighting in code blocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ notifications:
   email: false
 
 node_js:
-  - 4
   - 6
   - 8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
   email: false
 
 node_js:
-  - 6
+  - 6.9.5
   - 8
 
 before_install:

--- a/lib/plugin/language-alias.js
+++ b/lib/plugin/language-alias.js
@@ -28,5 +28,6 @@ var plugin = module.exports = function (md, opts) {
 }
 
 var languageAliases = plugin.languageAliases = {
-  bash: 'sh'
+  bash: 'sh',
+  typescript: 'ts'
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -102,6 +102,7 @@ render.renderPackageDescription = function (description) {
 }
 
 var mappings = {
+  jsx: 'source.js.jsx',
   sh: 'source.shell',
   markdown: 'source.gfm',
   erb: 'text.html.erb'

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -39,6 +39,7 @@ function getSanitizerConfig (options) {
         'js',
         'javascript',
         'json',
+        'jsx',
         'lang-html',
         'line',
         'sh',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1963,23 +1963,23 @@
       }
     },
     "first-mate": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-7.0.7.tgz",
-      "integrity": "sha1-q9V3gT4bA+OnE9NBT2v7z3oO9YQ=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-6.3.0.tgz",
+      "integrity": "sha1-3qQ530Rt4OoLi09WOoNPN9CtOT4=",
       "requires": {
         "emissary": "1.3.3",
         "event-kit": "2.3.0",
-        "fs-plus": "3.0.1",
+        "fs-plus": "2.10.1",
         "grim": "2.0.1",
-        "oniguruma": "6.2.1",
-        "season": "6.0.0",
+        "oniguruma": "6.1.1",
+        "season": "5.4.1",
         "underscore-plus": "1.6.6"
       },
       "dependencies": {
         "fs-plus": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
-          "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.10.1.tgz",
+          "integrity": "sha1-MgR4HXhAYR5jZOe2+wWMljJ8WqU=",
           "requires": {
             "async": "1.5.2",
             "mkdirp": "0.5.1",
@@ -1987,12 +1987,14 @@
             "underscore-plus": "1.6.6"
           }
         },
-        "oniguruma": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.2.1.tgz",
-          "integrity": "sha1-pQ7mlkKEStHSUmhaqxhxcbBuzgQ=",
+        "season": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/season/-/season-5.4.1.tgz",
+          "integrity": "sha1-S9baYVKn8tbwixQzzi2SBmmFPQ0=",
           "requires": {
-            "nan": "2.6.2"
+            "cson-parser": "1.0.9",
+            "fs-plus": "2.10.1",
+            "optimist": "0.4.0"
           }
         }
       }
@@ -2033,9 +2035,9 @@
       }
     },
     "fs-plus": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.10.1.tgz",
-      "integrity": "sha1-MgR4HXhAYR5jZOe2+wWMljJ8WqU=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
+      "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
       "requires": {
         "async": "1.5.2",
         "mkdirp": "0.5.1",
@@ -2298,13 +2300,13 @@
       }
     },
     "highlights": {
-      "version": "3.2.0-candidate.0",
-      "resolved": "https://registry.npmjs.org/highlights/-/highlights-3.2.0-candidate.0.tgz",
-      "integrity": "sha512-LcOU9oucu8T3RNR8zOKK7M+3q3QqLCSM7rrY0Pc8GRs2kOLDTmygV6Ihdm5BMlmYytOYVR7ds2arxhlk96BEjg==",
+      "version": "3.2.0-candidate.1",
+      "resolved": "https://registry.npmjs.org/highlights/-/highlights-3.2.0-candidate.1.tgz",
+      "integrity": "sha512-VW48P0g3cRHwaj7ZmHQhbyfL5r4A6tpvquV7CnOBTxAYHfv3SzC14bCl9c+ex100p1S8xlDO16dHx8Y5vgj21w==",
       "requires": {
-        "first-mate": "7.0.7",
+        "first-mate": "6.3.0",
         "first-mate-select-grammar": "1.0.1",
-        "fs-plus": "2.10.1",
+        "fs-plus": "3.0.1",
         "once": "1.4.0",
         "season": "6.0.0",
         "underscore-plus": "1.6.6",
@@ -3423,7 +3425,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.1.1.tgz",
       "integrity": "sha1-HH2W5T0RbriB2+eLg1W0rcgiWJg=",
-      "dev": true,
       "requires": {
         "nan": "2.6.2"
       }
@@ -3997,19 +3998,6 @@
         "cson-parser": "1.0.9",
         "fs-plus": "3.0.1",
         "optimist": "0.4.0"
-      },
-      "dependencies": {
-        "fs-plus": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
-          "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
-          "requires": {
-            "async": "1.5.2",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1",
-            "underscore-plus": "1.6.6"
-          }
-        }
       }
     },
     "semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,7 @@
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
       }
@@ -189,8 +189,7 @@
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "atom-language-diff": {
       "version": "1.0.2",
@@ -216,8 +215,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "1.2.1",
@@ -226,9 +224,9 @@
       "dev": true
     },
     "bn.js": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
-      "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA==",
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
     "boolbase": {
@@ -241,7 +239,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -299,7 +296,7 @@
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
         "browserify-zlib": "0.1.4",
-        "buffer": "5.0.6",
+        "buffer": "5.0.7",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
         "console-browserify": "1.1.0",
@@ -385,7 +382,7 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "randombytes": "2.0.5"
       }
     },
@@ -395,7 +392,7 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
@@ -414,9 +411,9 @@
       }
     },
     "buffer": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
-      "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg=",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.7.tgz",
+      "integrity": "sha512-NeeHXWh5pCbPQCt2/6rLvXqapZfVsqw/YgRgaHpT3H9Uzgs+S0lSg5SQzouIuDvcmlQRqBe8hOO2scKCu3cxrg==",
       "dev": true,
       "requires": {
         "base64-js": "1.2.1",
@@ -631,8 +628,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.5.2",
@@ -993,7 +989,7 @@
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "elliptic": "6.4.0"
       }
     },
@@ -1255,7 +1251,7 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "miller-rabin": "4.0.0",
         "randombytes": "2.0.5"
       }
@@ -1338,7 +1334,7 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "brorand": "1.1.0",
         "hash.js": "1.1.3",
         "hmac-drbg": "1.0.1",
@@ -1633,7 +1629,7 @@
         "debug": "2.6.8",
         "doctrine": "2.0.0",
         "escope": "3.6.0",
-        "espree": "3.4.3",
+        "espree": "3.5.0",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -1694,9 +1690,9 @@
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.1.tgz",
-      "integrity": "sha1-zU5GPQJo4tnnB/YfQvc/WzMzxkI=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
+      "integrity": "sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -1809,9 +1805,9 @@
       "dev": true
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
         "acorn": "5.1.1",
@@ -1967,17 +1963,38 @@
       }
     },
     "first-mate": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-6.3.0.tgz",
-      "integrity": "sha1-3qQ530Rt4OoLi09WOoNPN9CtOT4=",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-7.0.7.tgz",
+      "integrity": "sha1-q9V3gT4bA+OnE9NBT2v7z3oO9YQ=",
       "requires": {
         "emissary": "1.3.3",
         "event-kit": "2.3.0",
-        "fs-plus": "2.9.3",
+        "fs-plus": "3.0.1",
         "grim": "2.0.1",
-        "oniguruma": "6.1.1",
-        "season": "5.4.1",
+        "oniguruma": "6.2.1",
+        "season": "6.0.0",
         "underscore-plus": "1.6.6"
+      },
+      "dependencies": {
+        "fs-plus": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
+          "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
+          "requires": {
+            "async": "1.5.2",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "underscore-plus": "1.6.6"
+          }
+        },
+        "oniguruma": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.2.1.tgz",
+          "integrity": "sha1-pQ7mlkKEStHSUmhaqxhxcbBuzgQ=",
+          "requires": {
+            "nan": "2.6.2"
+          }
+        }
       }
     },
     "first-mate-select-grammar": {
@@ -2016,38 +2033,20 @@
       }
     },
     "fs-plus": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.9.3.tgz",
-      "integrity": "sha1-debXxX5FNklVoc+/xWP8WCDgz/I=",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.10.1.tgz",
+      "integrity": "sha1-MgR4HXhAYR5jZOe2+wWMljJ8WqU=",
       "requires": {
-        "async": "0.2.10",
-        "mkdirp": "0.3.5",
-        "rimraf": "2.2.8",
+        "async": "1.5.2",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
         "underscore-plus": "1.6.6"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        }
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.0",
@@ -2168,7 +2167,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2300,15 +2298,15 @@
       }
     },
     "highlights": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/highlights/-/highlights-2.1.3.tgz",
-      "integrity": "sha1-Bbl2Cg4BA2p0zhksupeWcHvK/Ek=",
+      "version": "3.2.0-candidate.0",
+      "resolved": "https://registry.npmjs.org/highlights/-/highlights-3.2.0-candidate.0.tgz",
+      "integrity": "sha512-LcOU9oucu8T3RNR8zOKK7M+3q3QqLCSM7rrY0Pc8GRs2kOLDTmygV6Ihdm5BMlmYytOYVR7ds2arxhlk96BEjg==",
       "requires": {
-        "first-mate": "6.3.0",
+        "first-mate": "7.0.7",
         "first-mate-select-grammar": "1.0.1",
-        "fs-plus": "2.9.3",
+        "fs-plus": "2.10.1",
         "once": "1.4.0",
-        "season": "5.4.1",
+        "season": "6.0.0",
         "underscore-plus": "1.6.6",
         "yargs": "4.8.1"
       }
@@ -2401,7 +2399,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -2792,9 +2789,9 @@
       "integrity": "sha1-5e8kjp5YaTFkfHzG9s1ZitggmVc="
     },
     "language-rust": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/language-rust/-/language-rust-0.4.11.tgz",
-      "integrity": "sha512-RnIymiRlwnU/rEwp+Ogsd2ZMHqO1mafuFFdc65pWH9kHbeY2tvbInUquWSbgcmU8Jqud2YNwxCPWO70dgzHf2w=="
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/language-rust/-/language-rust-0.4.12.tgz",
+      "integrity": "sha512-WLVVa5ftxhPiYMNjjfwr+GCVAPy/vFvP/FTAU4P+JiI9bfbZoF5QzEWi6n3Bb3E1S8Us3UGtoi78vRhEZMqnmQ=="
     },
     "language-stylus": {
       "version": "0.5.2",
@@ -3210,7 +3207,7 @@
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "brorand": "1.1.0"
       }
     },
@@ -3236,7 +3233,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -3244,8 +3240,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixto": {
       "version": "1.0.0",
@@ -3256,7 +3251,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -3429,6 +3423,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.1.1.tgz",
       "integrity": "sha1-HH2W5T0RbriB2+eLg1W0rcgiWJg=",
+      "dev": true,
       "requires": {
         "nan": "2.6.2"
       }
@@ -3563,8 +3558,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -3754,7 +3748,7 @@
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
@@ -3945,7 +3939,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -3997,13 +3990,26 @@
       }
     },
     "season": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/season/-/season-5.4.1.tgz",
-      "integrity": "sha1-S9baYVKn8tbwixQzzi2SBmmFPQ0=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/season/-/season-6.0.0.tgz",
+      "integrity": "sha1-etGII5B7yydf8Bs00ayp4sCJuYY=",
       "requires": {
         "cson-parser": "1.0.9",
-        "fs-plus": "2.9.3",
+        "fs-plus": "3.0.1",
         "optimist": "0.4.0"
+      },
+      "dependencies": {
+        "fs-plus": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
+          "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
+          "requires": {
+            "async": "1.5.2",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "underscore-plus": "1.6.6"
+          }
+        }
       }
     },
     "semver": {
@@ -4141,14 +4147,14 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "standard": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.2.tgz",
-      "integrity": "sha1-l0wcU8yGWwdaS1dueEQeFpXar3s=",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
+      "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
       "dev": true,
       "requires": {
         "eslint": "3.19.0",
         "eslint-config-standard": "10.2.1",
-        "eslint-config-standard-jsx": "4.0.1",
+        "eslint-config-standard-jsx": "4.0.2",
         "eslint-plugin-import": "2.2.0",
         "eslint-plugin-node": "4.2.3",
         "eslint-plugin-promise": "3.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,7 +189,8 @@
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "atom-language-diff": {
       "version": "1.0.2",
@@ -215,7 +216,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base64-js": {
       "version": "1.2.1",
@@ -239,6 +241,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -628,7 +631,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.5.2",
@@ -1963,27 +1967,17 @@
       }
     },
     "first-mate": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-7.0.7.tgz",
-      "integrity": "sha1-q9V3gT4bA+OnE9NBT2v7z3oO9YQ=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-6.3.0.tgz",
+      "integrity": "sha1-3qQ530Rt4OoLi09WOoNPN9CtOT4=",
       "requires": {
         "emissary": "1.3.3",
         "event-kit": "2.3.0",
-        "fs-plus": "3.0.1",
+        "fs-plus": "2.9.3",
         "grim": "2.0.1",
-        "oniguruma": "6.2.1",
-        "season": "6.0.0",
+        "oniguruma": "6.1.1",
+        "season": "5.4.1",
         "underscore-plus": "1.6.6"
-      },
-      "dependencies": {
-        "oniguruma": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.2.1.tgz",
-          "integrity": "sha1-pQ7mlkKEStHSUmhaqxhxcbBuzgQ=",
-          "requires": {
-            "nan": "2.6.2"
-          }
-        }
       }
     },
     "first-mate-select-grammar": {
@@ -2022,20 +2016,38 @@
       }
     },
     "fs-plus": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
-      "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.9.3.tgz",
+      "integrity": "sha1-debXxX5FNklVoc+/xWP8WCDgz/I=",
       "requires": {
-        "async": "1.5.2",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1",
+        "async": "0.2.10",
+        "mkdirp": "0.3.5",
+        "rimraf": "2.2.8",
         "underscore-plus": "1.6.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+        }
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.0",
@@ -2156,6 +2168,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2287,15 +2300,15 @@
       }
     },
     "highlights": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/highlights/-/highlights-3.1.0.tgz",
-      "integrity": "sha1-XK01QwZEiHa4/pbOWrEreCBFGZ4=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/highlights/-/highlights-2.1.3.tgz",
+      "integrity": "sha1-Bbl2Cg4BA2p0zhksupeWcHvK/Ek=",
       "requires": {
-        "first-mate": "7.0.7",
+        "first-mate": "6.3.0",
         "first-mate-select-grammar": "1.0.1",
-        "fs-plus": "3.0.1",
+        "fs-plus": "2.9.3",
         "once": "1.4.0",
-        "season": "6.0.0",
+        "season": "5.4.1",
         "underscore-plus": "1.6.6",
         "yargs": "4.8.1"
       }
@@ -2388,6 +2401,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -3222,6 +3236,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -3229,7 +3244,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mixto": {
       "version": "1.0.0",
@@ -3240,6 +3256,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -3412,7 +3429,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.1.1.tgz",
       "integrity": "sha1-HH2W5T0RbriB2+eLg1W0rcgiWJg=",
-      "dev": true,
       "requires": {
         "nan": "2.6.2"
       }
@@ -3547,7 +3563,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -3928,6 +3945,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -3979,12 +3997,12 @@
       }
     },
     "season": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/season/-/season-6.0.0.tgz",
-      "integrity": "sha1-etGII5B7yydf8Bs00ayp4sCJuYY=",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/season/-/season-5.4.1.tgz",
+      "integrity": "sha1-S9baYVKn8tbwixQzzi2SBmmFPQ0=",
       "requires": {
         "cson-parser": "1.0.9",
-        "fs-plus": "3.0.1",
+        "fs-plus": "2.9.3",
         "optimist": "0.4.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,7 +148,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.7.0"
+        "es-abstract": "1.8.0"
       }
     },
     "arrify": {
@@ -163,7 +163,7 @@
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
+        "bn.js": "4.11.7",
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
       }
@@ -187,9 +187,9 @@
       }
     },
     "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "atom-language-diff": {
       "version": "1.0.2",
@@ -209,25 +209,24 @@
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
-        "js-tokens": "3.0.1"
+        "js-tokens": "3.0.2"
       }
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
       "dev": true
     },
     "bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+      "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA==",
       "dev": true
     },
     "boolbase": {
@@ -237,12 +236,11 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-      "dev": true,
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "0.4.2",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -303,7 +301,7 @@
         "concat-stream": "1.5.2",
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.11.0",
+        "crypto-browserify": "3.11.1",
         "defined": "1.0.0",
         "deps-sort": "2.0.0",
         "domain-browser": "1.1.7",
@@ -325,13 +323,13 @@
         "punycode": "1.4.1",
         "querystring-es3": "0.2.1",
         "read-only-stream": "2.0.0",
-        "readable-stream": "2.2.11",
-        "resolve": "1.3.3",
+        "readable-stream": "2.3.3",
+        "resolve": "1.4.0",
         "shasum": "1.0.2",
         "shell-quote": "1.6.1",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.7.1",
-        "string_decoder": "1.0.2",
+        "stream-http": "2.7.2",
+        "string_decoder": "1.0.3",
         "subarg": "1.0.0",
         "syntax-error": "1.3.0",
         "through2": "2.0.3",
@@ -350,7 +348,7 @@
       "dev": true,
       "requires": {
         "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.3",
+        "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.0",
         "inherits": "2.0.3"
@@ -373,7 +371,7 @@
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.3",
+        "cipher-base": "1.0.4",
         "des.js": "1.0.0",
         "inherits": "2.0.3"
       }
@@ -384,7 +382,7 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
+        "bn.js": "4.11.7",
         "randombytes": "2.0.5"
       }
     },
@@ -394,7 +392,7 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
+        "bn.js": "4.11.7",
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
@@ -418,7 +416,7 @@
       "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.0",
+        "base64-js": "1.2.1",
         "ieee754": "1.1.8"
       }
     },
@@ -540,18 +538,19 @@
       }
     },
     "cipher-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
-      "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
@@ -629,8 +628,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.5.2",
@@ -687,16 +685,16 @@
       "dev": true
     },
     "conventional-changelog": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.3.tgz",
-      "integrity": "sha1-JigweKw4wJTfKvFgSwpGu8AWXE0=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.4.tgz",
+      "integrity": "sha1-EIvHUMKjF+IA4vm0E8qqH4x++js=",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.3.3",
-        "conventional-changelog-atom": "0.1.0",
+        "conventional-changelog-angular": "1.4.0",
+        "conventional-changelog-atom": "0.1.1",
         "conventional-changelog-codemirror": "0.1.0",
-        "conventional-changelog-core": "1.8.0",
-        "conventional-changelog-ember": "0.2.5",
+        "conventional-changelog-core": "1.9.0",
+        "conventional-changelog-ember": "0.2.6",
         "conventional-changelog-eslint": "0.1.0",
         "conventional-changelog-express": "0.1.0",
         "conventional-changelog-jquery": "0.1.0",
@@ -705,20 +703,80 @@
       }
     },
     "conventional-changelog-angular": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.3.tgz",
-      "integrity": "sha1-586AeoXdR1DhtBf3ZgRUl1EeByY=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.4.0.tgz",
+      "integrity": "sha512-ukKX22lJl9ewogze1hKbBuff/dGMG2uyGpOhhw0ehhlv6GtdeCxj51YfGOZ5qC89WwsHT7SDXFzBKidwH3pwmQ==",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
         "github-url-from-git": "1.5.0",
-        "q": "1.5.0"
+        "q": "1.5.0",
+        "read-pkg-up": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
       }
     },
     "conventional-changelog-atom": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz",
-      "integrity": "sha1-Z6R8ZqQrL4kJ7xWHyZia4d5zC5I=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.1.tgz",
+      "integrity": "sha512-6Nlu/+MiD4gi7k3Z+N1vMJWpaPSdvFPWzPGnH4OXewHAxiAl0L/TT9CGgA01fosPxmYr4hMNtD7kyN0tkg8vIA==",
       "dev": true,
       "requires": {
         "q": "1.5.0"
@@ -734,20 +792,20 @@
       }
     },
     "conventional-changelog-core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.8.0.tgz",
-      "integrity": "sha1-l3hItBbK8V+wnyCxKmLUDvFFuVc=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.0.tgz",
+      "integrity": "sha1-3l37wJGEdlZQjUo4njXJobxJ5/Q=",
       "dev": true,
       "requires": {
         "conventional-changelog-writer": "1.4.1",
         "conventional-commits-parser": "1.3.0",
         "dateformat": "1.0.12",
-        "get-pkg-repo": "1.3.0",
+        "get-pkg-repo": "1.4.0",
         "git-raw-commits": "1.2.0",
         "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.2.0",
+        "git-semver-tags": "1.2.1",
         "lodash": "4.17.4",
-        "normalize-package-data": "2.3.8",
+        "normalize-package-data": "2.4.0",
         "q": "1.5.0",
         "read-pkg": "1.1.0",
         "read-pkg-up": "1.0.1",
@@ -763,9 +821,9 @@
       }
     },
     "conventional-changelog-ember": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.5.tgz",
-      "integrity": "sha1-ziHVz4PNXr4F0j/fIy2IRPS1ak8=",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.6.tgz",
+      "integrity": "sha1-i3NVQZ9RJ0k8TFYkc6svx5LxwrY=",
       "dev": true,
       "requires": {
         "q": "1.5.0"
@@ -830,8 +888,8 @@
         "json-stringify-safe": "5.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
-        "semver": "5.3.0",
-        "split": "1.0.0",
+        "semver": "5.4.1",
+        "split": "1.0.1",
         "through2": "2.0.3"
       },
       "dependencies": {
@@ -877,18 +935,41 @@
       }
     },
     "conventional-recommended-bump": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.0.0.tgz",
-      "integrity": "sha1-bTA6J4N66Ti3xoyN3u00VZtLB4k=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.0.1.tgz",
+      "integrity": "sha512-2FrE8UJwt2EKpICi/E7P+xqyYUysdfMnFYiGV+7ANzJsixkBOrBKrKlCEV2NllCjR0XOmNfnA/mgozC5jAhhGQ==",
       "dev": true,
       "requires": {
         "concat-stream": "1.5.2",
         "conventional-commits-filter": "1.0.0",
-        "conventional-commits-parser": "1.3.0",
+        "conventional-commits-parser": "2.0.0",
         "git-raw-commits": "1.2.0",
-        "git-semver-tags": "1.2.0",
+        "git-semver-tags": "1.2.1",
         "meow": "3.7.0",
         "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "conventional-commits-parser": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.0.0.tgz",
+          "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
+          "dev": true,
+          "requires": {
+            "is-text-path": "1.0.1",
+            "JSONStream": "1.3.1",
+            "lodash": "4.17.4",
+            "meow": "3.7.0",
+            "split2": "2.1.1",
+            "through2": "2.0.3",
+            "trim-off-newlines": "1.0.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
       }
     },
     "convert-source-map": {
@@ -908,7 +989,7 @@
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
+        "bn.js": "4.11.7",
         "elliptic": "6.4.0"
       }
     },
@@ -918,7 +999,7 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.3",
+        "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "sha.js": "2.4.8"
@@ -930,28 +1011,29 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.3",
+        "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "safe-buffer": "5.0.1",
+        "safe-buffer": "5.1.1",
         "sha.js": "2.4.8"
       }
     },
     "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.0",
-        "which": "1.2.14"
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "crypto-browserify": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
-      "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
       "dev": true,
       "requires": {
         "browserify-cipher": "1.0.0",
@@ -961,7 +1043,7 @@
         "create-hmac": "1.1.6",
         "diffie-hellman": "5.0.2",
         "inherits": "2.0.3",
-        "pbkdf2": "3.0.12",
+        "pbkdf2": "3.0.13",
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.5"
       }
@@ -1018,7 +1100,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
       "requires": {
-        "es5-ext": "0.10.23"
+        "es5-ext": "0.10.26"
       }
     },
     "dargs": {
@@ -1055,12 +1137,12 @@
       }
     },
     "debug": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-      "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "dev": true,
       "requires": {
-        "ms": "0.7.2"
+        "ms": "2.0.0"
       }
     },
     "debug-log": {
@@ -1102,7 +1184,7 @@
       "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
       "dev": true,
       "requires": {
-        "find-root": "1.0.0",
+        "find-root": "1.1.0",
         "glob": "7.1.2",
         "ignore": "3.3.3",
         "pkg-config": "1.1.1",
@@ -1122,7 +1204,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.2.8"
+        "rimraf": "2.6.1"
       }
     },
     "deps-sort": {
@@ -1169,7 +1251,7 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
+        "bn.js": "4.11.7",
         "miller-rabin": "4.0.0",
         "randombytes": "2.0.5"
       }
@@ -1243,7 +1325,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.2.11"
+        "readable-stream": "2.3.3"
       }
     },
     "elliptic": {
@@ -1252,9 +1334,9 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
+        "bn.js": "4.11.7",
         "brorand": "1.1.0",
-        "hash.js": "1.0.3",
+        "hash.js": "1.1.3",
         "hmac-drbg": "1.0.1",
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0",
@@ -1291,13 +1373,14 @@
       }
     },
     "es-abstract": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
+      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.0",
+        "has": "1.0.1",
         "is-callable": "1.1.3",
         "is-regex": "1.0.4"
       }
@@ -1314,9 +1397,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.23",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
+      "version": "0.10.26",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
+      "integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
       "requires": {
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
@@ -1327,7 +1410,7 @@
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
-            "es5-ext": "0.10.23"
+            "es5-ext": "0.10.26"
           }
         },
         "es6-iterator": {
@@ -1336,7 +1419,7 @@
           "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.23",
+            "es5-ext": "0.10.26",
             "es6-symbol": "3.1.1"
           }
         },
@@ -1346,7 +1429,7 @@
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.23"
+            "es5-ext": "0.10.26"
           }
         }
       }
@@ -1357,7 +1440,7 @@
       "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
       "requires": {
         "d": "0.1.1",
-        "es5-ext": "0.10.23",
+        "es5-ext": "0.10.26",
         "es6-symbol": "2.0.1"
       }
     },
@@ -1368,7 +1451,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.23",
+        "es5-ext": "0.10.26",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -1381,7 +1464,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.23"
+            "es5-ext": "0.10.26"
           }
         },
         "es6-iterator": {
@@ -1391,7 +1474,7 @@
           "dev": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.23",
+            "es5-ext": "0.10.26",
             "es6-symbol": "3.1.1"
           }
         },
@@ -1402,7 +1485,7 @@
           "dev": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.23"
+            "es5-ext": "0.10.26"
           }
         }
       }
@@ -1414,7 +1497,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.23",
+        "es5-ext": "0.10.26",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1426,7 +1509,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.23"
+            "es5-ext": "0.10.26"
           }
         },
         "es6-iterator": {
@@ -1436,7 +1519,7 @@
           "dev": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.23",
+            "es5-ext": "0.10.26",
             "es6-symbol": "3.1.1"
           }
         },
@@ -1447,7 +1530,7 @@
           "dev": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.23"
+            "es5-ext": "0.10.26"
           }
         }
       }
@@ -1458,7 +1541,7 @@
       "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
       "requires": {
         "d": "0.1.1",
-        "es5-ext": "0.10.23"
+        "es5-ext": "0.10.26"
       }
     },
     "es6-weak-map": {
@@ -1467,7 +1550,7 @@
       "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
       "requires": {
         "d": "0.1.1",
-        "es5-ext": "0.10.23",
+        "es5-ext": "0.10.26",
         "es6-iterator": "0.1.3",
         "es6-symbol": "2.0.1"
       }
@@ -1486,7 +1569,7 @@
       "requires": {
         "es6-map": "0.1.5",
         "es6-weak-map": "2.0.2",
-        "esrecurse": "4.1.0",
+        "esrecurse": "4.2.0",
         "estraverse": "4.2.0"
       },
       "dependencies": {
@@ -1496,7 +1579,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.23"
+            "es5-ext": "0.10.26"
           }
         },
         "es6-iterator": {
@@ -1506,7 +1589,7 @@
           "dev": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.23",
+            "es5-ext": "0.10.26",
             "es6-symbol": "3.1.1"
           }
         },
@@ -1517,7 +1600,7 @@
           "dev": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.23"
+            "es5-ext": "0.10.26"
           }
         },
         "es6-weak-map": {
@@ -1527,7 +1610,7 @@
           "dev": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.23",
+            "es5-ext": "0.10.26",
             "es6-iterator": "2.0.1",
             "es6-symbol": "3.1.1"
           }
@@ -1543,7 +1626,7 @@
         "babel-code-frame": "6.22.0",
         "chalk": "1.1.3",
         "concat-stream": "1.5.2",
-        "debug": "2.6.0",
+        "debug": "2.6.8",
         "doctrine": "2.0.0",
         "escope": "3.6.0",
         "espree": "3.4.3",
@@ -1558,7 +1641,7 @@
         "inquirer": "0.12.0",
         "is-my-json-valid": "2.16.0",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.8.4",
+        "js-yaml": "3.9.1",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -1592,21 +1675,6 @@
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -1633,36 +1701,19 @@
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "2.6.0",
+        "debug": "2.6.8",
         "object-assign": "4.1.1",
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       }
     },
     "eslint-module-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
-      "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
+        "debug": "2.6.8",
         "pkg-dir": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
       }
     },
     "eslint-plugin-import": {
@@ -1673,10 +1724,10 @@
       "requires": {
         "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
-        "debug": "2.6.0",
+        "debug": "2.6.8",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.2.3",
-        "eslint-module-utils": "2.0.0",
+        "eslint-module-utils": "2.1.1",
         "has": "1.0.1",
         "lodash.cond": "4.5.2",
         "minimatch": "3.0.4",
@@ -1696,16 +1747,24 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.2.tgz",
-      "integrity": "sha1-gpWcqa7Xn8vSi7GxiNBcrAT7M2M=",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
+      "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
       "dev": true,
       "requires": {
         "ignore": "3.3.3",
         "minimatch": "3.0.4",
         "object-assign": "4.1.1",
-        "resolve": "1.3.3",
+        "resolve": "1.4.0",
         "semver": "5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-promise": {
@@ -1751,22 +1810,22 @@
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
       "dev": true,
       "requires": {
-        "acorn": "5.0.3",
+        "acorn": "5.1.1",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-          "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+          "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
           "dev": true
         }
       }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "esquery": {
@@ -1779,21 +1838,13 @@
       }
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.1.1",
+        "estraverse": "4.2.0",
         "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-          "dev": true
-        }
       }
     },
     "estraverse": {
@@ -1815,7 +1866,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.23"
+        "es5-ext": "0.10.26"
       },
       "dependencies": {
         "d": {
@@ -1824,7 +1875,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.23"
+            "es5-ext": "0.10.26"
           }
         }
       }
@@ -1850,13 +1901,13 @@
       }
     },
     "execa": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-      "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "4.0.2",
-        "get-stream": "2.3.1",
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
         "is-stream": "1.1.0",
         "npm-run-path": "2.0.2",
         "p-finally": "1.0.0",
@@ -1897,9 +1948,9 @@
       }
     },
     "find-root": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
-      "integrity": "sha1-li/yEaqyXGUg/u641ih/j26VgHo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
     },
     "find-up": {
@@ -1912,23 +1963,26 @@
       }
     },
     "first-mate": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-6.3.0.tgz",
-      "integrity": "sha1-3qQ530Rt4OoLi09WOoNPN9CtOT4=",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-7.0.7.tgz",
+      "integrity": "sha1-q9V3gT4bA+OnE9NBT2v7z3oO9YQ=",
       "requires": {
         "emissary": "1.3.3",
         "event-kit": "2.3.0",
-        "fs-plus": "2.9.3",
+        "fs-plus": "3.0.1",
         "grim": "2.0.1",
         "oniguruma": "6.2.1",
-        "season": "5.4.1",
+        "season": "6.0.0",
         "underscore-plus": "1.6.6"
       },
       "dependencies": {
         "oniguruma": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.2.1.tgz",
-          "integrity": "sha1-pQ7mlkKEStHSUmhaqxhxcbBuzgQ="
+          "integrity": "sha1-pQ7mlkKEStHSUmhaqxhxcbBuzgQ=",
+          "requires": {
+            "nan": "2.6.2"
+          }
         }
       }
     },
@@ -1946,7 +2000,7 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
+        "circular-json": "0.3.3",
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
@@ -1968,21 +2022,20 @@
       }
     },
     "fs-plus": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.9.3.tgz",
-      "integrity": "sha1-debXxX5FNklVoc+/xWP8WCDgz/I=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
+      "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
       "requires": {
-        "async": "0.2.10",
-        "mkdirp": "0.3.5",
-        "rimraf": "2.2.8",
+        "async": "1.5.2",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
         "underscore-plus": "1.6.6"
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.0",
@@ -2011,14 +2064,14 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-pkg-repo": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.3.0.tgz",
-      "integrity": "sha1-Q8a0wEi3XdYE/FOI7ezeVX9jNd8=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
+      "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.4.2",
+        "hosted-git-info": "2.5.0",
         "meow": "3.7.0",
-        "normalize-package-data": "2.3.8",
+        "normalize-package-data": "2.4.0",
         "parse-github-repo-url": "1.4.0",
         "through2": "2.0.3"
       }
@@ -2030,14 +2083,10 @@
       "dev": true
     },
     "get-stream": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-      "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "pinkie-promise": "2.0.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "git-raw-commits": {
       "version": "1.2.0",
@@ -2063,13 +2112,13 @@
       }
     },
     "git-semver-tags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-      "integrity": "sha1-sx/QLIq1eL1sm1ysyl4cZMEXesE=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.1.tgz",
+      "integrity": "sha512-fFyxtzTHCTQKwB4clA2AInVrlflBbVbbJD4NWwmxKXHUgsU/K9kmHNlkPLqFiuy9xu9q3lNopghR4VXeQwZbTQ==",
       "dev": true,
       "requires": {
         "meow": "3.7.0",
-        "semver": "5.3.0"
+        "semver": "5.4.1"
       }
     },
     "gitconfiglocal": {
@@ -2096,9 +2145,9 @@
       "dev": true
     },
     "github-url-to-object": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-4.0.0.tgz",
-      "integrity": "sha1-oze6WCGcFuqC08nMm8EJg3HG0cc=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-4.0.2.tgz",
+      "integrity": "sha1-EeIG1UJjtwGp47fMCaVbs4huDJc=",
       "requires": {
         "is-url": "1.2.2"
       }
@@ -2107,7 +2156,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2171,28 +2219,16 @@
         "async": "1.5.2",
         "optimist": "0.6.1",
         "source-map": "0.4.4",
-        "uglify-js": "2.8.28"
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
         "optimist": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.10",
+            "minimist": "0.0.8",
             "wordwrap": "0.0.3"
           }
         },
@@ -2241,24 +2277,25 @@
       }
     },
     "hash.js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
-      "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "highlights": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/highlights/-/highlights-2.1.3.tgz",
-      "integrity": "sha1-Bbl2Cg4BA2p0zhksupeWcHvK/Ek=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/highlights/-/highlights-3.1.0.tgz",
+      "integrity": "sha1-XK01QwZEiHa4/pbOWrEreCBFGZ4=",
       "requires": {
-        "first-mate": "6.3.0",
+        "first-mate": "7.0.7",
         "first-mate-select-grammar": "1.0.1",
-        "fs-plus": "2.9.3",
+        "fs-plus": "3.0.1",
         "once": "1.4.0",
-        "season": "5.4.1",
+        "season": "6.0.0",
         "underscore-plus": "1.6.6",
         "yargs": "4.8.1"
       }
@@ -2274,15 +2311,15 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.0.3",
+        "hash.js": "1.1.3",
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hosted-git-info": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "html-entities": {
       "version": "1.2.1",
@@ -2305,7 +2342,7 @@
         "domutils": "1.6.2",
         "entities": "1.1.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.2.11"
+        "readable-stream": "2.3.3"
       }
     },
     "https-browserify": {
@@ -2351,7 +2388,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -2618,19 +2654,19 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
-        "esprima": "3.1.3"
+        "esprima": "4.0.0"
       }
     },
     "json-stable-stringify": {
@@ -2742,9 +2778,9 @@
       "integrity": "sha1-5e8kjp5YaTFkfHzG9s1ZitggmVc="
     },
     "language-rust": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/language-rust/-/language-rust-0.4.10.tgz",
-      "integrity": "sha1-9PUN4JVtlPsEA1/r7DF6YXf8t0Q="
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/language-rust/-/language-rust-0.4.11.tgz",
+      "integrity": "sha512-RnIymiRlwnU/rEwp+Ogsd2ZMHqO1mafuFFdc65pWH9kHbeY2tvbInUquWSbgcmU8Jqud2YNwxCPWO70dgzHf2w=="
     },
     "language-stylus": {
       "version": "0.5.2",
@@ -3064,9 +3100,9 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.0.tgz",
-      "integrity": "sha512-aHGs865JXz6bkB4AHL+3AhyvTFKL3iZamKVWjIUKnXOXyasJvqPK8WAjOnAQKQZVpeXDVz19u1DD0r/12bWAdQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -3080,9 +3116,9 @@
       "dev": true
     },
     "markdown-it": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.3.1.tgz",
-      "integrity": "sha1-L0tiKUjM3Bk9ZvPKLUMSWsSscyM=",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.3.2.tgz",
+      "integrity": "sha512-4J92IhJq1kGoyXddwzzfjr9cEKGexBfFsZooKYMhMLLlWa4+dlSPDUUP7y+xQOCebIj61aLmKlowg//YcdPP1w==",
       "requires": {
         "argparse": "1.0.9",
         "entities": "1.1.1",
@@ -3092,9 +3128,9 @@
       }
     },
     "markdown-it-emoji": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.3.0.tgz",
-      "integrity": "sha1-kDrhqZaMPxfU4ULxFdTsV15W0ss="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz",
+      "integrity": "sha1-m+4OmpkKljupbfaYDE/dsF37Tcw="
     },
     "markdown-it-expand-tabs": {
       "version": "1.0.12",
@@ -3139,11 +3175,19 @@
         "loud-rejection": "1.6.0",
         "map-obj": "1.0.1",
         "minimist": "1.2.0",
-        "normalize-package-data": "2.3.8",
+        "normalize-package-data": "2.4.0",
         "object-assign": "4.1.1",
         "read-pkg-up": "1.0.1",
         "redent": "1.0.0",
         "trim-newlines": "1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "miller-rabin": {
@@ -3152,7 +3196,7 @@
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
+        "bn.js": "4.11.7",
         "brorand": "1.1.0"
       }
     },
@@ -3178,16 +3222,14 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
-        "brace-expansion": "1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixto": {
       "version": "1.0.0",
@@ -3195,19 +3237,22 @@
       "integrity": "sha1-wyDvYbUvKJj1IuF9i7xtUG2EJbY="
     },
     "mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
         "commander": "2.9.0",
-        "debug": "2.6.0",
+        "debug": "2.6.8",
         "diff": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
@@ -3230,21 +3275,6 @@
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
           }
         }
       }
@@ -3270,8 +3300,8 @@
         "inherits": "2.0.3",
         "JSONStream": "1.3.1",
         "parents": "1.0.1",
-        "readable-stream": "2.2.11",
-        "resolve": "1.3.3",
+        "readable-stream": "2.3.3",
+        "resolve": "1.4.0",
         "stream-combiner2": "1.1.1",
         "subarg": "1.0.0",
         "through2": "2.0.3",
@@ -3279,9 +3309,9 @@
       }
     },
     "ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "mute-stream": {
@@ -3293,8 +3323,7 @@
     "nan": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-      "dev": true
+      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -3303,13 +3332,13 @@
       "dev": true
     },
     "normalize-package-data": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.4.2",
+        "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
+        "semver": "5.4.1",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -3484,7 +3513,7 @@
         "browserify-aes": "1.0.6",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.0",
-        "pbkdf2": "3.0.12"
+        "pbkdf2": "3.0.13"
       }
     },
     "parse-github-repo-url": {
@@ -3518,8 +3547,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -3556,15 +3584,15 @@
       }
     },
     "pbkdf2": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
-      "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI=",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
+      "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
       "dev": true,
       "requires": {
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
         "ripemd160": "2.0.1",
-        "safe-buffer": "5.0.1",
+        "safe-buffer": "5.1.1",
         "sha.js": "2.4.8"
       }
     },
@@ -3632,7 +3660,7 @@
       "dev": true,
       "requires": {
         "debug-log": "1.0.1",
-        "find-root": "1.0.0",
+        "find-root": "1.1.0",
         "xtend": "4.0.1"
       }
     },
@@ -3709,7 +3737,7 @@
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
+        "bn.js": "4.11.7",
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
@@ -3746,15 +3774,7 @@
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-          "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
-          "dev": true
-        }
+        "safe-buffer": "5.1.1"
       }
     },
     "read-only-stream": {
@@ -3763,7 +3783,7 @@
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.2.11"
+        "readable-stream": "2.3.3"
       }
     },
     "read-pkg": {
@@ -3772,7 +3792,7 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
         "load-json-file": "1.1.0",
-        "normalize-package-data": "2.3.8",
+        "normalize-package-data": "2.4.0",
         "path-type": "1.1.0"
       }
     },
@@ -3786,16 +3806,16 @@
       }
     },
     "readable-stream": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.0.1",
-        "string_decoder": "1.0.2",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
       }
     },
@@ -3816,7 +3836,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       }
     },
     "redent": {
@@ -3870,9 +3890,9 @@
       }
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -3905,9 +3925,12 @@
       }
     },
     "rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "ripemd160": {
       "version": "2.0.1",
@@ -3941,9 +3964,9 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sanitize-html": {
       "version": "1.14.1",
@@ -3956,19 +3979,19 @@
       }
     },
     "season": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/season/-/season-5.4.1.tgz",
-      "integrity": "sha1-S9baYVKn8tbwixQzzi2SBmmFPQ0=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/season/-/season-6.0.0.tgz",
+      "integrity": "sha1-etGII5B7yydf8Bs00ayp4sCJuYY=",
       "requires": {
         "cson-parser": "1.0.9",
-        "fs-plus": "2.9.3",
+        "fs-plus": "3.0.1",
         "optimist": "0.4.0"
       }
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -3993,6 +4016,21 @@
         "json-stable-stringify": "0.0.1",
         "sha.js": "2.4.8"
       }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "shell-quote": {
       "version": "1.6.1",
@@ -4062,9 +4100,9 @@
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "split": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
         "through": "2.3.8"
@@ -4094,7 +4132,7 @@
         "eslint-config-standard": "10.2.1",
         "eslint-config-standard-jsx": "4.0.1",
         "eslint-plugin-import": "2.2.0",
-        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-node": "4.2.3",
         "eslint-plugin-promise": "3.5.0",
         "eslint-plugin-react": "6.10.3",
         "eslint-plugin-standard": "3.0.1",
@@ -4111,23 +4149,37 @@
         "get-stdin": "5.0.1",
         "minimist": "1.2.0",
         "pkg-conf": "2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "standard-version": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.1.0.tgz",
-      "integrity": "sha1-oEnofDAuf84j8vihjj7X8VCUNuw=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.2.0.tgz",
+      "integrity": "sha1-MBfoxc7SqS23UBeQJVw7qFFXN10=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "conventional-changelog": "1.1.3",
-        "conventional-recommended-bump": "1.0.0",
+        "conventional-changelog": "1.1.4",
+        "conventional-recommended-bump": "1.0.1",
         "figures": "1.7.0",
         "fs-access": "1.0.1",
-        "semver": "5.3.0",
-        "yargs": "8.0.1"
+        "semver": "5.4.1",
+        "yargs": "8.0.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -4162,12 +4214,12 @@
           }
         },
         "os-locale": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "0.5.1",
+            "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
           }
@@ -4188,7 +4240,7 @@
           "dev": true,
           "requires": {
             "load-json-file": "2.0.0",
-            "normalize-package-data": "2.3.8",
+            "normalize-package-data": "2.4.0",
             "path-type": "2.0.0"
           }
         },
@@ -4203,13 +4255,22 @@
           }
         },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "3.0.1"
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
           }
         },
         "strip-bom": {
@@ -4225,21 +4286,21 @@
           "dev": true
         },
         "yargs": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
-          "integrity": "sha1-Qg73XoQMFFeoCtzKm8b6OEneUao=",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
             "camelcase": "4.1.0",
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
             "get-caller-file": "1.0.2",
-            "os-locale": "2.0.0",
+            "os-locale": "2.1.0",
             "read-pkg-up": "2.0.0",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
-            "string-width": "2.0.0",
+            "string-width": "2.1.1",
             "which-module": "2.0.0",
             "y18n": "3.2.1",
             "yargs-parser": "7.0.0"
@@ -4263,7 +4324,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.2.11"
+        "readable-stream": "2.3.3"
       }
     },
     "stream-combiner2": {
@@ -4273,18 +4334,18 @@
       "dev": true,
       "requires": {
         "duplexer2": "0.1.4",
-        "readable-stream": "2.2.11"
+        "readable-stream": "2.3.3"
       }
     },
     "stream-http": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
-      "integrity": "sha1-VGpRdBrVprB+njGwsQRBqRffUoo=",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.2.11",
+        "readable-stream": "2.3.3",
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
@@ -4296,15 +4357,15 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.2.11"
+        "readable-stream": "2.3.3"
       }
     },
     "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "string-width": {
@@ -4369,6 +4430,14 @@
       "dev": true,
       "requires": {
         "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "supports-color": {
@@ -4400,9 +4469,15 @@
         "chalk": "1.1.3",
         "lodash": "4.17.4",
         "slice-ansi": "0.0.4",
-        "string-width": "2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -4416,13 +4491,22 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "3.0.1"
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -4451,7 +4535,7 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.2.11",
+        "readable-stream": "2.3.3",
         "xtend": "4.0.1"
       }
     },
@@ -4515,9 +4599,9 @@
       "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI="
     },
     "uglify-js": {
-      "version": "2.8.28",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.28.tgz",
-      "integrity": "sha512-WqKNbmNJKzIdIEQu/U2ytgGBbhCy2PVks94GoetczOAJ/zCgVu2CuO7gguI5KPFGPtUtI1dmPQl6h0D4cPzypA==",
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4674,9 +4758,9 @@
       }
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -4718,23 +4802,6 @@
       "dev": true,
       "requires": {
         "mkdirp": "0.5.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "atom-language-nginx": "^0.6.1",
     "github-slugger": "^1.0.0",
     "github-url-to-object": "^4.0.0",
-    "highlights": "^2.1.1",
+    "highlights": "^3.1.0",
     "highlights-tokens": "^1.0.1",
     "innertext": "^1.0.2",
     "is-plain-obj": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "atom-language-nginx": "^0.6.1",
     "github-slugger": "^1.0.0",
     "github-url-to-object": "^4.0.0",
-    "highlights": "^3.2.0-candidate.0",
+    "highlights": "^3.2.0-candidate.1",
     "highlights-tokens": "^1.0.1",
     "innertext": "^1.0.2",
     "is-plain-obj": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "atom-language-nginx": "^0.6.1",
     "github-slugger": "^1.0.0",
     "github-url-to-object": "^4.0.0",
-    "highlights": "^2.1.3",
+    "highlights": "^3.2.0-candidate.0",
     "highlights-tokens": "^1.0.1",
     "innertext": "^1.0.2",
     "is-plain-obj": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "atom-language-nginx": "^0.6.1",
     "github-slugger": "^1.0.0",
     "github-url-to-object": "^4.0.0",
-    "highlights": "^3.1.0",
+    "highlights": "^2.1.3",
     "highlights-tokens": "^1.0.1",
     "innertext": "^1.0.2",
     "is-plain-obj": "^1.1.0",

--- a/test/cdn.js
+++ b/test/cdn.js
@@ -1,12 +1,10 @@
-/* globals before, describe, it */
-
-var assert = require('assert')
+/* var assert = require('assert')
 var marky = require('..')
 var fixtures = require('./fixtures')
 var cheerio = require('cheerio')
 
 describe('cdn', function () {
-  describe('handles missing or empty package data', function () {
+  /* describe('handles missing or empty package data', function () {
     var controlHtml
 
     before(function () {
@@ -108,3 +106,4 @@ describe('cdn', function () {
     })
   })
 })
+*/

--- a/test/fixtures/basic.md
+++ b/test/fixtures/basic.md
@@ -40,6 +40,19 @@ alert "hi"
 +added
 ```
 
+```jsx
+class Thinger extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+  render() {
+    return (
+      <div>{this.whatever}</div>
+    )
+  }
+}
+```
+
 Mustache {{template}} variable {{do.not.replace}}
 
 ```js

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -29,7 +29,7 @@ describe('markdown processing', function () {
 
     it('converts leading tabs in code blocks to spaces', function () {
       var $ = cheerio.load(marky(fixtures.basic))
-      var indentHtml = $('.highlight.js .line .comment span:not(.js)').html()
+      var indentHtml = $('.highlight.js .line .meta:first-of-type > .meta:first-of-type > span:not(.js):first-of-type').html()
       assert(!~indentHtml.indexOf('\t'))
       assert(~indentHtml.indexOf('&#xA0;'))
     })
@@ -194,6 +194,11 @@ describe('markdown processing', function () {
       assert($('.highlight.diff').length)
     })
 
+    it('adds jsx class to jsx blocks', function () {
+      assert(~fixtures.basic.indexOf('```jsx'))
+      assert($('.highlight.jsx').length)
+    })
+
     it('wraps code highlighter output in div.highlight', function () {
       // the idea here is that we have a 1:1 correspondence of <div class='highlight'>
       // and their contained <pre class='editor'> elements coming from the highlighter
@@ -220,6 +225,10 @@ describe('markdown processing', function () {
     it('applies inline syntax highlighting classes to diffs', function () {
       assert($('.diff.inserted').length)
       assert($('.diff.deleted').length)
+    })
+
+    it('applies inline syntax highlighting classes to jsx', function () {
+      assert($('.jsx .js.keyword').length)
     })
 
     it('does not encode entities within code blocks', function () {


### PR DESCRIPTION
This will add support for highlighting JSX code blocks, once [highlights#55](https://github.com/atom/highlights/pull/55) is merged upstream.

Fixes #395