### PR TITLE
fix Uncaught TypeError: Cannot read property 'highlightSync' of undefined

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -60,7 +60,7 @@ render.getParser = function (options) {
     linkify: options.linkify
   }
 
-  if (options.highlightSyntax) {
+  if (typeof process.browser === 'undefined' && options.highlightSyntax) {
     mdOptions.highlight = function (code, lang) {
       if (!lang) { return '' }
       return highlighter.highlightSync({
@@ -87,7 +87,7 @@ render.getParser = function (options) {
     .use(looseLinkParsing)
     .use(looseImageParsing)
 
-  if (options.highlightSyntax) parser.use(codeWrap)
+  if (typeof process.browser === 'undefined' && options.highlightSyntax) parser.use(codeWrap)
   if (options.serveImagesWithCDN) parser.use(cdnImages, {package: options.package})
 
   return githubLinkify(parser)


### PR DESCRIPTION
Since [browser side highlight](https://github.com/npm/marky-markdown#in-the-browser) is not supported, and the default `highlightSyntax` is set to true, I just ran into this error easily:

<img width="1280" alt="screen shot 2017-07-08 at 11 33 46 pm" src="https://user-images.githubusercontent.com/1091472/27986776-03c9d3e0-6436-11e7-913f-c75b3d69eded.png">

The problem is at https://github.com/npm/marky-markdown/blob/master/lib/render.js#L66 where `highlighter` is `undefined` because it's only `require` when [`typeof process.browser === 'undefined'`](https://github.com/npm/marky-markdown/blob/master/lib/render.js#L25).

This pull request should hopefully fix it.