### PR TITLE
Update webpack part

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,15 @@ Here is an example using HTML5 to render text inside `<marky-markdown>` tags.
 
 Note: Usage with [webpack](https://webpack.github.io/) requires that your
 `webpack.config.js` configure a loader (such as
-[json-loader](https://github.com/webpack/json-loader)) for .json files.
+[json-loader](https://github.com/webpack/json-loader)) for .json files. Also, you need to config `process.browser` in `webpack.config.js` when you target browser:
+
+```js
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.browser': true
+    })
+  ],
+```
 
 ## Tests
 


### PR DESCRIPTION
Since webpack doesn't expose `process.browser` as browserify, when I build with webpack targeting browser, I got this error:

> ERROR in ./node_modules/oniguruma/build/Release/onig_scanner.node
Module parse failed: /Users/sam/Documents/githubRepos/writedown/app/node_modules/oniguruma/build/Release/onig_scanner.node Unexpected character '�' (1:0)
You may need an appropriate loader to handle this file type.
(Source code omitted for this binary file)
 @ ./node_modules/oniguruma/src/oniguruma.js 1:34-79
 @ ./node_modules/first-mate/lib/grammar.js
 @ ./node_modules/first-mate/lib/first-mate.js
 @ ./node_modules/highlights/lib/highlights.js
 @ ./node_modules/marky-markdown/lib/render.js
 @ ./node_modules/marky-markdown/index.js
 @ ./src/index.js

Define `'process.browser'` in `webpack.config.js` would workaround it.