### PR TITLE
Treat `bash` the same as `sh` for specifying code fence language

### DIFF
--- a/lib/plugin/language-alias.js
+++ b/lib/plugin/language-alias.js
@@ -1,0 +1,32 @@
+// This plugin allows for code fences written in certain languages to be rendered
+// as though they'd been written in a different language, e.g.,
+//
+//     ```bash
+//     $ marky-markdown test.md
+//     ```
+//
+// can have the exact same output as
+//
+//     ```sh
+//     $ marky-markdown test.md
+//     ```
+//
+// (doing the normal thing and setting up a syntax highlighter mapping in our
+// render module would almost work, except the wrapping <div> still has the
+// "bash" class applied)
+//
+
+var plugin = module.exports = function (md, opts) {
+  var previousFenceRule = md.renderer.rules.fence
+  md.renderer.rules.fence = function (tokens, idx, options, env, slf) {
+    // code fence language marker is in token.info; do we have an alias?
+    if (languageAliases.hasOwnProperty(tokens[idx].info)) {
+      tokens[idx].info = languageAliases[tokens[idx].info]
+    }
+    return previousFenceRule.call(this, tokens, idx, options, env, slf)
+  }
+}
+
+var languageAliases = plugin.languageAliases = {
+  bash: 'sh'
+}

--- a/lib/render.js
+++ b/lib/render.js
@@ -16,6 +16,7 @@ var youtube = require('./plugin/youtube')
 var cdnImages = require('./plugin/cdn')
 var packagize = require('./plugin/packagize')
 var htmlHeading = require('./plugin/html-heading')
+var fenceLanguageAliasing = require('./plugin/language-alias')
 var relaxedLinkRefs = require('./gfm/relaxed-link-reference')
 var githubHeadings = require('./gfm/indented-headings')
 var overrideLinkDestinationParser = require('./gfm/override-link-destination-parser')
@@ -87,7 +88,10 @@ render.getParser = function (options) {
     .use(looseLinkParsing)
     .use(looseImageParsing)
 
-  if (options.highlightSyntax) parser.use(codeWrap)
+  if (options.highlightSyntax) {
+    parser.use(codeWrap)
+          .use(fenceLanguageAliasing)
+  }
   if (options.serveImagesWithCDN) parser.use(cdnImages, {package: options.package})
 
   return githubLinkify(parser)

--- a/test/fixtures/basic.md
+++ b/test/fixtures/basic.md
@@ -27,6 +27,10 @@ app.listen(3000)
 echo hi
 ```
 
+```bash
+echo hi
+```
+
 ```coffeescript
 alert "hi"
 ```

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -178,6 +178,12 @@ describe('markdown processing', function () {
       assert($('.highlight.sh').length)
     })
 
+    it('adds sh class to bash blocks', function () {
+      assert(~fixtures.basic.indexOf('```bash'))
+      assert($('.highlight.sh').length)
+      assert.equal($('.highlight.bash').length, 0)
+    })
+
     it('adds coffeescript class to coffee blocks', function () {
       assert(~fixtures.basic.indexOf('```coffee'))
       assert($('.highlight.coffeescript').length)


### PR DESCRIPTION
This _almost_ worked by adding a language mapping to the `render` module, but the wrapping `<div>` element for the rendered code block still had `class="highlight bash"` rather than `class="highlight sh"`, so I wrote a tiny markdown-it plugin to allow us to set up language aliases for code fence rendering.

Fixes #400