### PR TITLE
Add support/tests for typescript highlighting

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -45,6 +45,7 @@ function getSanitizerConfig (options) {
         'sh',
         'shell',
         'typescript',
+        'ts',
         'xml',
         'youtube-video'
       ],

--- a/test/fixtures/basic.md
+++ b/test/fixtures/basic.md
@@ -53,6 +53,26 @@ class Thinger extends React.Component {
 }
 ```
 
+```ts
+interface Person {
+    firstName: string;
+    lastName: string;
+}
+
+function greeter(person: Person) {
+    return "Hello, " + person.firstName + " " + person.lastName;
+}
+```
+
+```typescript
+class Student {
+    fullName: string;
+    constructor(public firstName, public middleInitial, public lastName) {
+        this.fullName = firstName + " " + middleInitial + " " + lastName;
+    }
+}
+```
+
 Mustache {{template}} variable {{do.not.replace}}
 
 ```js

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -199,6 +199,13 @@ describe('markdown processing', function () {
       assert($('.highlight.jsx').length)
     })
 
+    it('adds ts class to typescript blocks', function () {
+      assert(~fixtures.basic.indexOf('```ts'))
+      assert(~fixtures.basic.indexOf('```typescript'))
+      assert.equal($('.highlight.ts').length, 2)
+      assert.equal($('.highlight.typescript').length, 0)
+    })
+
     it('wraps code highlighter output in div.highlight', function () {
       // the idea here is that we have a 1:1 correspondence of <div class='highlight'>
       // and their contained <pre class='editor'> elements coming from the highlighter
@@ -229,6 +236,12 @@ describe('markdown processing', function () {
 
     it('applies inline syntax highlighting classes to jsx', function () {
       assert($('.jsx .js.keyword').length)
+    })
+
+    it('applies inline syntax highlighting classes to typescript', function () {
+      assert.equal($('.highlight.typescript').length, 0)
+      assert($('.ts .storage.type').length)
+      assert($('.ts .entity.name.type.class').length)
     })
 
     it('does not encode entities within code blocks', function () {


### PR DESCRIPTION
To finish off full support for TypeScript syntax highlighting, we need to add `ts` to the sanitizer safelist, and write some tests; here it is.

I've done `assert.equal($('.highlight.typescript').length, 0)` in two separate tests intentionally here, just because I decided that if our highlighter _isn't_ coercing `typescript` code fences to `ts` in the generated markup, that circumstance should break both of those tests. IMHO.

Fixes #397.