### PR TITLE
feat(dep): bump oniguruma

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1981,7 +1981,6 @@
         "event-kit": "2.3.0",
         "fs-plus": "2.10.1",
         "grim": "2.0.1",
-        "oniguruma": "6.1.1",
         "season": "5.4.1",
         "underscore-plus": "1.6.6"
       },
@@ -3336,7 +3335,8 @@
     "nan": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -3422,9 +3422,10 @@
       "dev": true
     },
     "oniguruma": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.1.1.tgz",
-      "integrity": "sha1-HH2W5T0RbriB2+eLg1W0rcgiWJg=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-7.0.0.tgz",
+      "integrity": "sha512-VcMkJvwl3rycLzgh5yhefMEGlSfMEuxnhwmMus/UCqAKlOdzE0Z46exkgLfe6ISX4XuLbqWvSXvkK26eJ/2jIw==",
+      "dev": true,
       "requires": {
         "nan": "2.6.2"
       }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "glob": "^7.1.1",
     "intercept-stdout": "^0.1.2",
     "mocha": "^3.4.1",
-    "oniguruma": "~6.1.1",
+    "oniguruma": "^7.0.0",
     "standard": "^10.0.0",
     "standard-version": "^4.1.0"
   },


### PR DESCRIPTION
oniguruma released a minor version that broke node 4 support. version 7 returns node 4 support. this PR bumps onig to that version.