### PR TITLE
Bump sanitize-html version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "markdown-it-lazy-headers": "^0.1.3",
     "markdown-it-task-lists": "^2.0.1",
     "property-ttl": "^1.0.0",
-    "sanitize-html": "^1.6.1",
+    "sanitize-html": "^1.14.1",
     "similarity": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
It looks like sanitize-html is outdated and has some security vulnerabilities. 
This PR bumps that package to the latest version. 