### PR TITLE
Process all image/link URLs during github rewrites

### DIFF
--- a/lib/plugin/github.js
+++ b/lib/plugin/github.js
@@ -37,7 +37,10 @@ function replaceTagAttribute (html, tag, attribute, buildUrl, repository) {
       // Skip fully-qualified URLs, #hash fragments, and protocol-relative URLs
       if (!url.host && url.path && !url.path.match(/^\/\//)) {
         var newUrl = buildUrl(repository, url)
-        return html.slice(0, attr.index) + attr[0] + quote + newUrl + quote + substring.slice(src[0].length + 1)
+        var htmlPrefix = html.slice(0, attr.index) + attr[0] + quote + newUrl + quote
+        var htmlPostfix = substring.slice(src[0].length + 1)
+        var processedPostfix = replaceTagAttribute(htmlPostfix, tag, attribute, buildUrl, repository)
+        return htmlPrefix + (processedPostfix || htmlPostfix)
       }
     }
   }

--- a/test/fixtures/github.md
+++ b/test/fixtures/github.md
@@ -55,6 +55,9 @@ Smiley! :)
 # Heading with nested image/link: <a href="nested/link/image"><img src="nested/link/image/image.png"></a>. Nice.
 
 <img src="html/block.png" />
+<br />
+<img src="html/block2.png" />
 
-<p><a href="html/block.html">Link in an HTML block</a></p>
+<p><a href="html/block.html">Link in an HTML block</a>
+and <a href="html/block2.html">second link</a></p>
 

--- a/test/repo-github.js
+++ b/test/repo-github.js
@@ -49,10 +49,13 @@ describe('when package repo is on github', function () {
   it('rewrites slashy relative links hrefs to absolute (HTML)', function () {
     assert(~fixtures.github.indexOf('<a href="nested/link/image">'))
     assert(~fixtures.github.indexOf('<a href="html/block.html">Link in an HTML block</a>'))
+    assert(~fixtures.github.indexOf('<a href="html/block2.html">second link</a>'))
     assert($("a[href='https://github.com/mark/wahlberg/blob/HEAD/nested/link/image']").length)
     assert($("a[href='https://github.com/mark/wahlberg/blob/HEAD/html/block.html']").length)
+    assert($("a[href='https://github.com/mark/wahlberg/blob/HEAD/html/block2.html']").length)
     assert($short("a[href='https://github.com/mark/wahlberg/blob/HEAD/nested/link/image']").length)
     assert($short("a[href='https://github.com/mark/wahlberg/blob/HEAD/html/block.html']").length)
+    assert($short("a[href='https://github.com/mark/wahlberg/blob/HEAD/html/block2.html']").length)
   })
 
   it('leaves protocol-relative URLs alone', function () {
@@ -101,10 +104,13 @@ describe('when package repo is on github', function () {
   it('replaces slashy relative img URLs with github URLs (HTML)', function () {
     assert(~fixtures.github.indexOf('<img src="nested/link/image/image.png">'))
     assert(~fixtures.github.indexOf('<img src="html/block.png" />'))
+    assert(~fixtures.github.indexOf('<img src="html/block2.png" />'))
     assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/nested/link/image/image.png']").length)
     assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/html/block.png']").length)
+    assert($("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/html/block2.png']").length)
     assert($short("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/nested/link/image/image.png']").length)
     assert($short("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/html/block.png']").length)
+    assert($short("img[src='https://raw.githubusercontent.com/mark/wahlberg/HEAD/html/block2.png']").length)
   })
 
   it('leaves protocol relative URLs alone', function () {


### PR DESCRIPTION
The github URL-rewriting markdown-it plugin was accidentally only doing a single URL replacement per `html_block`; this change recursively processes every occurrence instead.