### PR TITLE
Webpack support

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -41,7 +41,9 @@ if (typeof process.browser === 'undefined') {
 
   languages.forEach(function (language) {
     highlighter.requireGrammarsSync({
-      modulePath: require.resolve(language + '/package.json')
+      // the eval is a workaround for a Webpack issue with resolving numbers instead of paths
+      // check https://github.com/webpack/webpack/issues/1554#issuecomment-158679844
+      modulePath: eval("require.resolve(language + '/package.json')")
     })
   })
 


### PR DESCRIPTION
Wrapped the _require.resolve_ with an eval in order to avoid getting a number instead of the file path using Webpack. Check [https://github.com/webpack/webpack/issues/1554#issuecomment-158679844](https://github.com/webpack/webpack/issues/1554#issuecomment-158679844)