### PR TITLE
[WIP] Add formatting based on lang for html_blocks

### DIFF
--- a/lib/plugin/html-block.js
+++ b/lib/plugin/html-block.js
@@ -1,0 +1,38 @@
+//https://regex101.com/r/cS4Ly1/3/
+var EXTRACT_LANG_REGEX = /<pre(?:\s[^<|>]*?)lang=(?:'|")(\w+)(?:'|")/
+//https://regex101.com/r/cS4Ly1/2
+var EXTRACT_CONTENT_REGEX = /<pre(?:\s[^<|>]*?)>((.|\n)*)<\/pre>/
+var langMap = {
+  'javascript': 'js',
+  'bash': 'sh'
+}
+
+var plugin = module.exports = function(md, opts) {
+  var originalBlockRule = md.renderer.rules.html_block
+  md.renderer.rules.html_block = function(tokens, idx, options, env, self) {
+    var output = originalBlockRule.call(this, tokens, idx, options, env, self)
+    if (tokens[idx].type === 'html_block') {
+      var langMatches = tokens[idx].content.match(EXTRACT_LANG_REGEX)
+      if (langMatches[1] === 'javascript' || langMatches[1] === 'bash') {
+        var langName = langMap[langMatches[1]]
+        var contentMatches = tokens[idx].content.match(EXTRACT_CONTENT_REGEX)
+        tokens[idx].content = options.highlight(contentMatches[1].trim(), langName)
+        
+        var token = tokens[idx]
+        var index = token.attrIndex('class')
+        var attributes = token.attrs ? token.attrs.slice() : []
+        var classes = options.langPrefix + ' ' + langName
+        attributes.push(['class', classes])
+    
+        var fakeToken = {
+          attrs: attributes
+        }
+
+        return '<' + plugin.tag + slf.renderAttrs(fakeToken) + '>' + output + '</' + plugin.tag + '>\n'
+      }
+    }
+    return output
+  }
+}
+
+plugin.tag = 'div'

--- a/lib/render.js
+++ b/lib/render.js
@@ -22,6 +22,7 @@ var githubHeadings = require('./gfm/indented-headings')
 var overrideLinkDestinationParser = require('./gfm/override-link-destination-parser')
 var looseLinkParsing = require('./gfm/link')
 var looseImageParsing = require('./gfm/image')
+var htmlBlock = require('./plugin/html-block')
 
 if (typeof process.browser === 'undefined') {
   var Highlights = require('highlights')
@@ -87,6 +88,7 @@ render.getParser = function (options) {
     .use(overrideLinkDestinationParser)
     .use(looseLinkParsing)
     .use(looseImageParsing)
+    .use(htmlBlock)
 
   if (options.highlightSyntax) {
     parser.use(codeWrap)


### PR DESCRIPTION
@revin The existing README highlighting for oojs: https://npm.im/oojs
The fixed highlighting after this change: https://auspicious-thread.surge.sh

Approach:
1. Add a plugin which overrides the html_block renderer
2. If a pre tag is available with, it checks if the lang is javascript/bash. (Couldnt find a more comprehensive list of supported langs but new ones can be added without issues)
3. Extract content from the html block
4. Replace token content with this
5. calls the parent html_block renderer and then uses the code from https://github.com/npm/marky-markdown/blob/master/lib/plugin/code-wrap.js to wrap this generated html into a code highlighting wrapper

Overall this seems to fix the issue. I'd like to get your feedback on whether I solved it in the right way. Also, I'm a little confused as to how I should go about adding tests for this. Any help/advice would be appreciated.

---
Fixes #402