### PR TITLE
YouTube embed handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ var defaultOptions = {
   debug: false,
   package: null,
   headingAnchorClass: 'anchor',
-  headingSvgClass: ['octicon', 'octicon-link']
+  headingSvgClass: ['octicon', 'octicon-link'],
+  allowDeprecatedYoutubeEmbeds: false
 }
 
 var marky = module.exports = function (markdown, options) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -94,9 +94,7 @@ render.getParser = function (options) {
 
   if (options.serveImagesWithCDN) parser.use(cdnImages, {package: options.package})
 
-  if (options.allowDeprecatedYoutubeEmbeds) {
-    parser.use(youtube)
-  }
+  if (options.allowDeprecatedYoutubeEmbeds) parser.use(youtube)
 
   return githubLinkify(parser)
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -81,7 +81,6 @@ render.getParser = function (options) {
     .use(relaxedLinkRefs)
     .use(gravatar)
     .use(github, {package: options.package})
-    .use(youtube)
     .use(packagize, {package: options.package})
     .use(htmlHeading)
     .use(overrideLinkDestinationParser)
@@ -92,7 +91,12 @@ render.getParser = function (options) {
     parser.use(codeWrap)
           .use(fenceLanguageAliasing)
   }
+
   if (options.serveImagesWithCDN) parser.use(cdnImages, {package: options.package})
+
+  if (options.allowDeprecatedYoutubeEmbeds) {
+    parser.use(youtube)
+  }
 
   return githubLinkify(parser)
 }

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -93,7 +93,9 @@ function getSanitizerConfig (options) {
 
       // Allow YouTube iframes
       if (frame.tag !== 'iframe') return false
-      return !String(frame.attribs.src).match(/^(https?:)?\/\/(www\.)?youtube\.com/)
+
+      var isYouTube = String(frame.attribs.src).match(/^(https?:)?\/\/(www\.)?youtube\.com/)
+      return !(isYouTube && options.allowDeprecatedYoutubeEmbeds)
     },
     transformTags: {
       'td': sanitizeCellStyle,

--- a/test/sanitize.js
+++ b/test/sanitize.js
@@ -58,10 +58,15 @@ describe('sanitize', function () {
     assert.equal($('s').text(), 'orange')
   })
 
-  it('disallows iframes from sources other than youtube', function () {
+  it('disallows all iframes by default', function () {
     var $ = cheerio.load(marky(fixtures.basic))
     assert(~fixtures.basic.indexOf('<iframe src="//www.youtube.com/embed/3I78ELjTzlQ'))
     assert(~fixtures.basic.indexOf('<iframe src="//malware.com'))
+    assert.equal($('iframe').length, 0)
+  })
+
+  it('allows iframes from youtube if `allowDeprecatedYoutubeEmbeds` is set to true', function () {
+    var $ = cheerio.load(marky(fixtures.basic, {allowDeprecatedYoutubeEmbeds: true}))
     assert.equal($('iframe').length, 2)
     assert.equal($('iframe').eq(0).attr('src'), '//www.youtube.com/embed/3I78ELjTzlQ')
     assert.equal($('iframe').eq(1).attr('src'), 'https://www.youtube.com/embed/DN4yLZB1vUQ')

--- a/test/youtube.js
+++ b/test/youtube.js
@@ -10,7 +10,7 @@ describe('youtube', function () {
   var iframes
 
   before(function () {
-    $ = cheerio.load(marky(fixtures.basic))
+    $ = cheerio.load(marky(fixtures.basic, {allowDeprecatedYoutubeEmbeds: true}))
     iframes = $('.youtube-video > iframe')
   })
 


### PR DESCRIPTION
Like discussed in #274 this "deprecates" the youtube plugin. 

- Youtube plugin disabled by default, add option to enable it
- Sanitizer allows YouTube iframes only if the option is turned on
- Altered youtube test and turned the option on there
- Altered sanitizer tests to check that by all iframes are removed and only if the option is turned on the youtube iframes are let through.