### PR TITLE
feature: add rel=nofollow to links if the `nofollow` option is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The default options are as follows:
 ```js
 {
   sanitize: true,               // remove script tags and stuff
+  nofollow: true,               // add rel=nofollow to all links
   linkify: true,                // turn orphan URLs into hyperlinks
   highlightSyntax: true,        // run highlights on fenced code blocks
   prefixHeadingIds: true,       // prevent DOM id collisions

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ var marky = module.exports = function (markdown, options) {
 }
 
 marky.parsePackageDescription = function (description) {
-  return sanitize(render.renderPackageDescription(description))
+  return sanitize(render.renderPackageDescription(description), defaultOptions)
 }
 
 marky.getParser = function (options) {
@@ -74,7 +74,7 @@ marky.getParser = function (options) {
   if (options.sanitize) {
     var originalRender = parser.render
     parser.render = function (markdown) {
-      return sanitize(originalRender.call(parser, markdown))
+      return sanitize(originalRender.call(parser, markdown), options)
     }
   }
   return parser

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var markyInfo = require('./marky.json')
 
 var defaultOptions = {
   sanitize: true,
+  nofollow: true,
   linkify: true,
   highlightSyntax: true,
   prefixHeadingIds: true,

--- a/lib/plugin/nofollow.js
+++ b/lib/plugin/nofollow.js
@@ -1,0 +1,12 @@
+// Set rel=nofollow on all links if we have set `nofollow` in the options.
+
+module.exports = function (md, options) {
+  var defaultRender = md.renderer.rules.link_open || function (tokens, idx, options, env, self) {
+    return self.renderToken(tokens, idx, options)
+  }
+
+  md.renderer.rules.link_open = function handleLink (tokens, idx, options, env, self) {
+    tokens[idx].attrPush(['rel', 'nofollow'])
+    return defaultRender(tokens, idx, options, env, self)
+  }
+}

--- a/lib/render.js
+++ b/lib/render.js
@@ -22,6 +22,7 @@ var githubHeadings = require('./gfm/indented-headings')
 var overrideLinkDestinationParser = require('./gfm/override-link-destination-parser')
 var looseLinkParsing = require('./gfm/link')
 var looseImageParsing = require('./gfm/image')
+var relNoFollow = require('./plugin/nofollow')
 
 if (typeof process.browser === 'undefined') {
   var Highlights = require('highlights')
@@ -87,6 +88,10 @@ render.getParser = function (options) {
     .use(overrideLinkDestinationParser)
     .use(looseLinkParsing)
     .use(looseImageParsing)
+
+  if (options.nofollow) {
+    parser.use(relNoFollow)
+  }
 
   if (options.highlightSyntax) {
     parser.use(codeWrap)

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -6,7 +6,8 @@ module.exports = function (html, options) {
       transformTags: {
         '*': prefixHTMLids,
         'td': sanitizeCellStyle,
-        'th': sanitizeCellStyle
+        'th': sanitizeCellStyle,
+        'a': getNofollowSanitize(options)
       }
     })
   } else {
@@ -97,9 +98,28 @@ function getSanitizerConfig (options) {
     },
     transformTags: {
       'td': sanitizeCellStyle,
-      'th': sanitizeCellStyle
+      'th': sanitizeCellStyle,
+      'a': getNofollowSanitize(options)
     }
   }
+}
+
+function getNofollowSanitize (options) {
+  return options.nofollow ? sanitizeAnchorNofollow : sanitizeIdentity
+}
+
+function sanitizeIdentity (tagName, attribs) {
+  return {
+    tagName: tagName,
+    attribs: attribs
+  }
+}
+
+function sanitizeAnchorNofollow (tagName, attribs) {
+  if (attribs.href) {
+    attribs.rel = 'nofollow'
+  }
+  return sanitizeIdentity(tagName, attribs)
 }
 
 // Allow table cell alignment

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -66,7 +66,7 @@ function getSanitizerConfig (options) {
       h4: ['id', 'align'],
       h5: ['id', 'align'],
       h6: ['id', 'align'],
-      a: ['href', 'id', 'name', 'target', 'title', 'aria-hidden'],
+      a: ['href', 'id', 'name', 'target', 'title', 'aria-hidden', 'rel'],
       img: ['alt', 'id', 'src', 'width', 'height', 'align', 'valign', 'title', 'style'],
       p: ['align'],
       meta: ['name', 'content'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,8 +148,7 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array.prototype.find": {
       "version": "2.0.4",
@@ -603,6 +602,19 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.0.tgz",
       "integrity": "sha1-dJLLvD8DYcxdiGWv9yN1Uv8z4fc="
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combine-source-map": {
       "version": "0.7.2",
@@ -1568,8 +1580,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escope": {
       "version": "3.6.0",
@@ -2965,6 +2976,11 @@
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.cond": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
@@ -2986,6 +3002,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
     "lodash.filter": {
       "version": "4.6.0",
@@ -3045,6 +3066,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
       "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
       "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
     },
     "lodash.pick": {
       "version": "4.4.0",
@@ -3716,6 +3742,64 @@
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
+    "postcss": {
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+      "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+      "requires": {
+        "chalk": "2.3.0",
+        "source-map": "0.6.1",
+        "supports-color": "5.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -3877,11 +3961,6 @@
         "strip-indent": "1.0.1"
       }
     },
-    "regexp-quote": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz",
-      "integrity": "sha1-Hg9GUMhi3L/tVP1CsUjpuxch/PI="
-    },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
@@ -3997,13 +4076,51 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sanitize-html": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.14.1.tgz",
-      "integrity": "sha1-cw/6Ikm98YMz7/5FsoYXPJxa0Lg=",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.17.0.tgz",
+      "integrity": "sha512-5r265ukJgS+MXVMK0OxXLn7iBqRTIxYK0m6Bc+/gFhCY20Vr/KFp/ZTKu9hyB3tKkiGPiQ08aGDPUbjbBhRpXw==",
       "requires": {
+        "chalk": "2.3.0",
         "htmlparser2": "3.9.2",
-        "regexp-quote": "0.0.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.escaperegexp": "4.1.2",
+        "lodash.mergewith": "4.6.0",
+        "postcss": "6.0.16",
+        "srcset": "1.0.0",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "season": {
@@ -4149,6 +4266,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "srcset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
+      "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
+      "requires": {
+        "array-uniq": "1.0.3",
+        "number-is-nan": "1.0.1"
+      }
     },
     "standard": {
       "version": "10.0.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "markdown-it-lazy-headers": "^0.1.3",
     "markdown-it-task-lists": "^2.0.1",
     "property-ttl": "^1.0.0",
-    "sanitize-html": "^1.14.1",
+    "sanitize-html": "^1.17.0",
     "similarity": "^1.0.1"
   },
   "devDependencies": {

--- a/test/nofollow.js
+++ b/test/nofollow.js
@@ -1,0 +1,18 @@
+
+/* globals describe, it */
+
+var assert = require('assert')
+var marky = require('..')
+var cheerio = require('cheerio')
+
+describe('nofollow plugin', function () {
+  it('adds rel=nofollow attributes to links', function () {
+    var rendered = cheerio.load(marky('[link text](https://example.com/spam)'))
+    assert.equal(rendered('a').attr('rel'), 'nofollow')
+  })
+
+  it('respects the option to turn off nofollow', function () {
+    var rendered = cheerio.load(marky('[link text](https://example.com/spam)', { nofollow: false }))
+    assert.equal(rendered('a').attr('rel'), undefined)
+  })
+})

--- a/test/nofollow.js
+++ b/test/nofollow.js
@@ -15,4 +15,14 @@ describe('nofollow plugin', function () {
     var rendered = cheerio.load(marky('[link text](https://example.com/spam)', { nofollow: false }))
     assert.equal(rendered('a').attr('rel'), undefined)
   })
+
+  it('adds rel=nofollow attributes to html links', function () {
+    var rendered = cheerio.load(marky('<a href=https://example.com/spam>link text</a>'))
+    assert.equal(rendered('a').attr('rel'), 'nofollow')
+  })
+
+  it('respects the option to turn off nofollow for html', function () {
+    var rendered = cheerio.load(marky('<a href=https://example.com/spam>link text</a>', { nofollow: false }))
+    assert.equal(rendered('a').attr('rel'), undefined)
+  })
 })

--- a/test/packagize.js
+++ b/test/packagize.js
@@ -74,7 +74,7 @@ describe('packagize', function () {
 
     it('parses description as markdown and removes script tags', function () {
       var description = marky.parsePackageDescription('bad <script>/xss</script> [hax](http://hax.com)')
-      assert.equal(description, 'bad  <a href="http://hax.com">hax</a>')
+      assert.equal(description, 'bad  <a href="http://hax.com" rel="nofollow">hax</a>')
     })
 
     it('safely handles inline code blocks', function () {

--- a/test/sanitize.js
+++ b/test/sanitize.js
@@ -63,7 +63,7 @@ describe('sanitize', function () {
     assert(~fixtures.basic.indexOf('<iframe src="//www.youtube.com/embed/3I78ELjTzlQ'))
     assert(~fixtures.basic.indexOf('<iframe src="//malware.com'))
     assert.equal($('iframe').length, 2)
-    assert.equal($('iframe').eq(0).attr('src'), '//www.youtube.com/embed/3I78ELjTzlQ')
+    assert.equal($('iframe').eq(0).attr('src'), 'https://www.youtube.com/embed/3I78ELjTzlQ')
     assert.equal($('iframe').eq(1).attr('src'), 'https://www.youtube.com/embed/DN4yLZB1vUQ')
   })
 
@@ -108,20 +108,21 @@ describe('sanitize', function () {
 
   it('allows table cell left alignment', function () {
     var html = marky(fixtures.dirty)
-    assert(html.indexOf('<th style="text-align:left">') > -1)
-    assert(html.indexOf('<td style="text-align:left">') > -1)
+    console.info(html)
+    assert(html.indexOf('<th style="text-align:left;">') > -1)
+    assert(html.indexOf('<td style="text-align:left;">') > -1)
   })
 
   it('allows table cell right alignment', function () {
     var html = marky(fixtures.dirty)
-    assert(html.indexOf('<th style="text-align:right">') > -1)
-    assert(html.indexOf('<td style="text-align:right">') > -1)
+    assert(html.indexOf('<th style="text-align:right;">') > -1)
+    assert(html.indexOf('<td style="text-align:right;">') > -1)
   })
 
   it('allows table cell center alignment', function () {
     var html = marky(fixtures.dirty)
-    assert(html.indexOf('<th style="text-align:center">') > -1)
-    assert(html.indexOf('<td style="text-align:center">') > -1)
+    assert(html.indexOf('<th style="text-align:center;">') > -1)
+    assert(html.indexOf('<td style="text-align:center;">') > -1)
   })
 
   it('strips non-alignment table cell style', function () {

--- a/test/youtube.js
+++ b/test/youtube.js
@@ -27,7 +27,7 @@ describe('youtube', function () {
 
   it('preserves existing src, frameborder, and allowfullscreen properties', function () {
     var iframe = iframes.eq(0)
-    assert.equal(iframe.attr('src'), '//www.youtube.com/embed/3I78ELjTzlQ')
+    assert.equal(iframe.attr('src'), 'https://www.youtube.com/embed/3I78ELjTzlQ')
     assert.equal(iframe.attr('frameborder'), '0')
     assert.equal(iframe.attr('allowfullscreen'), '')
   })


### PR DESCRIPTION
- Added a plugin that adds rel=nofollow to links and does no more.
- Added an option to control if the plugin is loaded, defaulted to true, and documented the option.
- Wrote tests to verify that the rel attr is added, and that the option is respected.
- Added `rel` to the allowed list of attributes in the sanitizer.