### PR TITLE
feat: handle subdirectories when building relative link URLs

### DIFF
--- a/lib/plugin/github.js
+++ b/lib/plugin/github.js
@@ -13,7 +13,16 @@ function buildImageUrl (repository, url) {
 }
 
 function buildLinkUrl (repository, url) {
-  return repository.https_url + path.join('/blob/' + DEFAULT_REF + '/', url.href)
+  // preserve prefix if repository url already contains /tree/<rev> or /blob/<rev>
+  var match = /^(\/(?:tree|blob)\/[^/]+)(?:\/|$)/.exec(repository.path)
+  var prefix = '/blob/' + DEFAULT_REF
+  var subdir = '/'
+  if (match) {
+    prefix = match[1]
+    // preserve subdirectory in repository url unless url is absolute
+    subdir = repository.path.substr(prefix.length)
+  }
+  return repository.clone_url + prefix + path.posix.resolve('/', subdir, url.href)
 }
 
 // search the provided HTML snippet and rewrite the attribute on the given tag

--- a/test/repo-github.js
+++ b/test/repo-github.js
@@ -134,4 +134,20 @@ describe('when package repo is on github', function () {
     errorPkg.url = ''
     assert(marky(fixtures.github, {package: errorPkg}).length)
   })
+
+  it('handles subdirectories in repository.url', function () {
+    var errorPkg = {
+      name: 'wahlberg',
+      repository: {
+        type: 'git',
+        url: 'https://github.com/mark/wahlberg/tree/master/subdir'
+      }}
+    var $ = cheerio.load(marky(fixtures.github, { package: errorPkg }))
+
+    assert(~fixtures.github.indexOf('(relative/file.js)'))
+    assert($("a[href='https://github.com/mark/wahlberg/tree/master/subdir/relative/file.js']").length)
+
+    assert(~fixtures.github.indexOf('(/slashy/poo)'))
+    assert($("a[href='https://github.com/mark/wahlberg/tree/master/slashy/poo']").length)
+  })
 })


### PR DESCRIPTION
This fixes an issue with relative links in packages maintained in a monorepo (described at https://npm.community/t/relative-link-in-readme-of-monorepo/3806)

You basically set `repository.url` in `package.json` to the subdirectory that contains the sources of the package. In my case that's https://github.com/fimbullinter/wotan/tree/master/packages/mimir
All relative links are relative to that URL. Absolute links are relative to the repository root.

Previously it would always append `/blob/HEAD/<link>` after the full URL.