### PR TITLE
feat: upgrade to node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
   email: false
 
 node_js:
-  - 8
+  - 12
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/lib/render.js
+++ b/lib/render.js
@@ -5,7 +5,7 @@ var emoji = require('markdown-it-emoji')
 var expandTabs = require('markdown-it-expand-tabs')
 var githubTaskList = require('markdown-it-task-lists')
 
-var cleanup = require('./cleanup')
+// var cleanup = require('./cleanup')
 var githubLinkify = require('./linkify')
 
 var codeWrap = require('./plugin/code-wrap')
@@ -48,7 +48,11 @@ if (typeof process.browser === 'undefined') {
 
   // cleanup generated rules in the highlighter registry if they are idle for 2000ms
   // they take a tremendous amount of memory if you process many languages in a server type environment.
-  cleanup(highlighter.registry.grammars)
+
+  // this doesn't work with new highlights version,
+  // so we need to evaluate mem consumption due to this change
+  // before rolling this change out
+  // cleanup(highlighter.registry.grammars)
 }
 
 var render = module.exports = function (markdown, options) {

--- a/marky.json
+++ b/marky.json
@@ -1,1 +1,1 @@
-{"version":"12.0.3","repositoryUrl":"https://github.com/npm/marky-markdown","issuesUrl":"https://github.com/npm/marky-markdown/issues"}
+{"version":"13.0.0","repositoryUrl":"https://github.com/npm/marky-markdown","issuesUrl":"https://github.com/npm/marky-markdown/issues"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcorp/marky-markdown",
-  "version": "12.0.3",
+  "version": "13.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -469,9 +469,9 @@
       "dev": true
     },
     "camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -600,9 +600,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "coffee-script": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.0.tgz",
-      "integrity": "sha1-dJLLvD8DYcxdiGWv9yN1Uv8z4fc="
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
     "color-convert": {
       "version": "1.9.1",
@@ -1072,11 +1072,11 @@
       }
     },
     "cson-parser": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.0.9.tgz",
-      "integrity": "sha1-t5/BuCp3V0NoDw7/uL+tMRNNrHQ=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
+      "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
       "requires": {
-        "coffee-script": "1.9.0"
+        "coffee-script": "^1.10.0"
       }
     },
     "css-select": {
@@ -1903,9 +1903,9 @@
       }
     },
     "event-kit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.3.0.tgz",
-      "integrity": "sha1-RZugZG1Lfbyl2b8rPE4tAQPoXhU="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.5.3.tgz",
+      "integrity": "sha512-b7Qi1JNzY4BfAYfnIRanLk0DOD1gdkWHT4GISIn8Q2tAf3LpU8SP2CMwWaq40imYoKWbtN4ZhbSRxvsnikooZQ=="
     },
     "events": {
       "version": "1.1.1",
@@ -1985,56 +1985,40 @@
       }
     },
     "first-mate": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-6.3.0.tgz",
-      "integrity": "sha1-3qQ530Rt4OoLi09WOoNPN9CtOT4=",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-7.4.1.tgz",
+      "integrity": "sha512-SEG5W0aajCvK/Ngoo3he3Ib4DsT+CRPhBAgSju5hksBLvvUfRWP7Jf3+HQ+CNTD4GZZqbDNOEJNOxbf35EblrQ==",
       "requires": {
         "emissary": "^1",
         "event-kit": "^2.2.0",
-        "fs-plus": "^2",
+        "fs-plus": "^3.0.0",
         "grim": "^2.0.1",
-        "oniguruma": "^6.1.0",
-        "season": "^5.0.2",
+        "oniguruma": "7.2.1",
+        "season": "^6.0.2",
         "underscore-plus": "^1"
       },
       "dependencies": {
-        "fs-plus": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.10.1.tgz",
-          "integrity": "sha1-MgR4HXhAYR5jZOe2+wWMljJ8WqU=",
-          "requires": {
-            "async": "^1.5.2",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.2",
-            "underscore-plus": "1.x"
-          }
+        "nan": {
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
         },
         "oniguruma": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.2.1.tgz",
-          "integrity": "sha1-pQ7mlkKEStHSUmhaqxhxcbBuzgQ=",
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-7.2.1.tgz",
+          "integrity": "sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==",
           "requires": {
-            "nan": "^2.0.9"
-          }
-        },
-        "season": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/season/-/season-5.4.1.tgz",
-          "integrity": "sha1-S9baYVKn8tbwixQzzi2SBmmFPQ0=",
-          "requires": {
-            "cson-parser": "1.0.9",
-            "fs-plus": "2.x",
-            "optimist": "~0.4.0"
+            "nan": "^2.14.0"
           }
         }
       }
     },
     "first-mate-select-grammar": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/first-mate-select-grammar/-/first-mate-select-grammar-1.0.1.tgz",
-      "integrity": "sha1-LdBqgeKd9Y6GZ2hUSr6pukJDzNg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/first-mate-select-grammar/-/first-mate-select-grammar-1.0.3.tgz",
+      "integrity": "sha512-OTGt//jDdzPAzny8hpxhg6SHpkeFhOAj26egYqusY78twKk9vpyMBqIVtm6TE2Q7ccM0p21gnNFadIUbyDFmJQ==",
       "requires": {
-        "lodash": "^3.10.1"
+        "lodash": "^4.17.11"
       }
     },
     "flat-cache": {
@@ -2065,9 +2049,9 @@
       }
     },
     "fs-plus": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
-      "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.1.1.tgz",
+      "integrity": "sha512-Se2PJdOWXqos1qVTkvqqjb0CSnfBnwwD+pq+z4ksT+e97mEShod/hrNg0TRCCsXPbJzcIq+NuzQhigunMWMJUA==",
       "requires": {
         "async": "^1.5.2",
         "mkdirp": "^0.5.1",
@@ -2240,9 +2224,9 @@
       "dev": true
     },
     "grim": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.1.tgz",
-      "integrity": "sha1-Kyb4kmmfObX2lSveWI589AcLab4=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.3.tgz",
+      "integrity": "sha512-FM20Ump11qYLK9k9DbL8yzVpy+YBieya1JG15OeH8s+KbHq8kL4SdwRtURwIUHniSxb24EoBUpwKfFjGNVi4/Q==",
       "requires": {
         "event-kit": "^2.0.0"
       }
@@ -2336,15 +2320,15 @@
       "dev": true
     },
     "highlights": {
-      "version": "3.2.0-candidate.1",
-      "resolved": "https://registry.npmjs.org/highlights/-/highlights-3.2.0-candidate.1.tgz",
-      "integrity": "sha512-VW48P0g3cRHwaj7ZmHQhbyfL5r4A6tpvquV7CnOBTxAYHfv3SzC14bCl9c+ex100p1S8xlDO16dHx8Y5vgj21w==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/highlights/-/highlights-3.1.4.tgz",
+      "integrity": "sha512-sba+ho6gC2IgMe2+c4Tk2T7Ba+z9OOHaXmpbaGFlk7EQ/sS9Fp5CZYV1gnTHH8+AHlg9HqAwOIQe/E74ciMCTQ==",
       "requires": {
-        "first-mate": "^6.3.0",
-        "first-mate-select-grammar": "^1.0.1",
-        "fs-plus": "^3.0.1",
+        "first-mate": "^7.0.2",
+        "first-mate-select-grammar": "^1.0.3",
+        "fs-plus": "^3.0.0",
         "once": "^1.3.2",
-        "season": "^6.0.0",
+        "season": "^6.0.2",
         "underscore-plus": "^1.5.1",
         "yargs": "^4.7.1"
       }
@@ -2905,9 +2889,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -3380,7 +3364,8 @@
     "nan": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -3472,14 +3457,6 @@
       "dev": true,
       "requires": {
         "nan": "^2.0.9"
-      }
-    },
-    "optimist": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.4.0.tgz",
-      "integrity": "sha1-y47Dfy/jqphky2eidSUOfhliCiU=",
-      "requires": {
-        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -4128,13 +4105,29 @@
       }
     },
     "season": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/season/-/season-6.0.0.tgz",
-      "integrity": "sha1-etGII5B7yydf8Bs00ayp4sCJuYY=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/season/-/season-6.0.2.tgz",
+      "integrity": "sha1-naWPsd3SSCTXYhstxjpxI7UCF7Y=",
       "requires": {
-        "cson-parser": "1.0.9",
+        "cson-parser": "^1.3.0",
         "fs-plus": "^3.0.0",
-        "optimist": "~0.4.0"
+        "yargs": "^3.23.0"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
       }
     },
     "semver": {
@@ -4830,16 +4823,16 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
+      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
     },
     "underscore-plus": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
-      "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.7.0.tgz",
+      "integrity": "sha512-A3BEzkeicFLnr+U/Q3EyWwJAQPbA19mtZZ4h+lLq3ttm9kn8WC4R3YpuJZEXmWdLjYP47Zc8aLZm9kwdv+zzvA==",
       "requires": {
-        "underscore": "~1.6.0"
+        "underscore": "^1.9.1"
       }
     },
     "uniq": {
@@ -4930,14 +4923,15 @@
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "window-size": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -4997,6 +4991,13 @@
         "window-size": "^0.2.0",
         "y18n": "^3.2.1",
         "yargs-parser": "^2.4.1"
+      },
+      "dependencies": {
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+        }
       }
     },
     "yargs-parser": {
@@ -5006,6 +5007,13 @@
       "requires": {
         "camelcase": "^3.0.0",
         "lodash.assign": "^4.0.6"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3362,9 +3362,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true
     },
     "natural-compare": {
@@ -3451,12 +3451,12 @@
       "dev": true
     },
     "oniguruma": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-7.0.0.tgz",
-      "integrity": "sha512-VcMkJvwl3rycLzgh5yhefMEGlSfMEuxnhwmMus/UCqAKlOdzE0Z46exkgLfe6ISX4XuLbqWvSXvkK26eJ/2jIw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-7.2.1.tgz",
+      "integrity": "sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==",
       "dev": true,
       "requires": {
-        "nan": "^2.0.9"
+        "nan": "^2.14.0"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@npmcorp/marky-markdown",
-  "version": "12.0.3",
+  "version": "13.0.0",
   "description": "npm's markdown parser",
   "main": "index.js",
   "scripts": {
     "prebuild": "node bin/build-marky-info.js",
     "build": "rm -rf dist && mkdir dist && touch dist/marky-markdown.js && browserify index.js -i highlights -s markyMarkdown > dist/marky-markdown.js",
     "test": "standard --fix && mocha --timeout 8000",
+    "test:debug": "standard --fix && mocha --inspect-brk --timeout 8000",
     "pretest": "npm run build",
     "prepublish": "npm run build",
     "release": "standard-version --commit-all"
@@ -47,7 +48,7 @@
     "atom-language-nginx": "^0.6.1",
     "github-slugger": "^1.2.0",
     "github-url-to-object": "^4.0.0",
-    "highlights": "^3.2.0-candidate.1",
+    "highlights": "^3.1.4",
     "highlights-tokens": "^1.0.1",
     "innertext": "^1.0.2",
     "is-plain-obj": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "glob": "^7.1.1",
     "intercept-stdout": "^0.1.2",
     "mocha": "^3.5.3",
-    "oniguruma": "^7.0.0",
+    "oniguruma": "^7.2.1",
     "standard": "^10.0.0",
     "standard-version": "^4.1.0"
   },


### PR DESCRIPTION
- Update `highlights` to use newer oniguruma dependency, which otherwise won't compile on Node 12.
- Remove cleanup grammar code, which doesn't work with newer `highlights`. While trying to solve some memory consumption issues, the code is actually an antipattern, which mutates the state of `highlighter` object. I kept the code for now to discuss how we want to proceed with the change.

Closes https://github.com/npm/marky-markdown/issues/442

Related to github/npm#1814﻿
